### PR TITLE
[TB-3899] Update subscription text depending on the willRenew flag

### DIFF
--- a/application/lib/infrastructure/service/payment/fake_payment_service.dart
+++ b/application/lib/infrastructure/service/payment/fake_payment_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:injectable/injectable.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
@@ -13,12 +14,14 @@ import 'package:xayn_discovery_app/presentation/constants/constants.dart';
 class FakePaymentService implements PaymentService {
   final StreamController<PurchaserInfo> _controller =
       StreamController<PurchaserInfo>.broadcast();
+  final _randomNumberGenerator = Random();
 
   @override
   Stream<PurchaserInfo> get purchaserInfoStream => _controller.stream;
 
   /// Allow to test the purchase flow for non-release builds.
   bool _hasMockActiveSubscription = false;
+  bool _willRenew = false;
 
   FakePaymentService();
 
@@ -35,11 +38,14 @@ class FakePaymentService implements PaymentService {
     PurchaseType type = PurchaseType.subs,
   }) {
     _hasMockActiveSubscription = true;
+    _willRenew = _randomNumberGenerator.nextBool();
     return Future.delayed(
       PaymentMockData.requestSimulationDuration,
       () {
         final purchaserInfo = PaymentMockData.createPurchaserInfo(
-            withActiveSubscription: _hasMockActiveSubscription);
+          withActiveSubscription: _hasMockActiveSubscription,
+          willRenew: _willRenew,
+        );
         _controller.sink.add(purchaserInfo);
         return purchaserInfo;
       },
@@ -49,11 +55,14 @@ class FakePaymentService implements PaymentService {
   @override
   Future<PurchaserInfo> restore() {
     _hasMockActiveSubscription = true;
+    _willRenew = _randomNumberGenerator.nextBool();
     return Future.delayed(
       PaymentMockData.requestSimulationDuration,
       () {
         final purchaserInfo = PaymentMockData.createPurchaserInfo(
-            withActiveSubscription: _hasMockActiveSubscription);
+          withActiveSubscription: _hasMockActiveSubscription,
+          willRenew: _willRenew,
+        );
         _controller.sink.add(purchaserInfo);
         return purchaserInfo;
       },
@@ -63,7 +72,9 @@ class FakePaymentService implements PaymentService {
   @override
   Future<PurchaserInfo> getPurchaserInfo() =>
       Future.value(PaymentMockData.createPurchaserInfo(
-          withActiveSubscription: _hasMockActiveSubscription));
+        withActiveSubscription: _hasMockActiveSubscription,
+        willRenew: _willRenew,
+      ));
 
   @override
   Future<void> presentCodeRedemptionSheet() => Future.value();

--- a/application/lib/infrastructure/service/payment/payment_mock_data.dart
+++ b/application/lib/infrastructure/service/payment/payment_mock_data.dart
@@ -44,13 +44,14 @@ class PaymentMockData {
     status: PurchasableProductStatus.purchasable,
   );
 
-  static PurchaserInfo createPurchaserInfo(
-      {bool withActiveSubscription = true}) {
+  static PurchaserInfo createPurchaserInfo({
+    bool withActiveSubscription = true,
+    bool willRenew = false,
+  }) {
     const subscriptionId = productId;
     const entitlementId = EntitlementIds.unlimited;
     final tomorrow = DateTime.now().add(const Duration(days: 1));
     final isActive = withActiveSubscription;
-    final willRenew = withActiveSubscription;
     final entitlementInfo = EntitlementInfo(
       entitlementId,
       isActive,

--- a/application/lib/presentation/constants/translations/translations.i18n.dart
+++ b/application/lib/presentation/constants/translations/translations.i18n.dart
@@ -224,6 +224,26 @@ class Translations {
   String get takeSurveySubtitle =>
       """We'd love your opinion on how to make the app better""";
   String get takeSurveyCTA => """Take me to the survey""";
+  String get addExcludedSource =>
+      """Add a source to exclude it from your feed""";
+  String get addTrustedSource =>
+      """Which news sources do you want to follow?""";
+  String get addSourcePlaceholder => """Search or enter URL""";
+  String get addSourceDescription => """Search for a source name or its URL""";
+  String get btnSave => """Save""";
+  String get trustedSourcesTab => """Favorite news sources""";
+  String get excludedSourcesTab => """Hidden sources""";
+  String get trustedSourcesDescription =>
+      """Add your favorite news outlets to your feed""";
+  String get btnAdd => """Add a news source""";
+  String get excludedSourcesDescription =>
+      """These sources will no longer appear in your feed.""";
+  String get sourcePendingAddition =>
+      """This source will be added to the list""";
+  String get sourcePendingRemoval =>
+      """This source was just removed from the list""";
+  String get settingsGiveFeedback => """Give feedback""";
+  String get subscriptionExpiresText => """The subscription expires on: %s""";
 }
 
 class PaymentFlowErrorTranslations {
@@ -444,4 +464,21 @@ Map<String, String> get translationsMap => {
       """takeSurveySubtitle""":
           """We'd love your opinion on how to make the app better""",
       """takeSurveyCTA""": """Take me to the survey""",
+      """addExcludedSource""": """Add a source to exclude it from your feed""",
+      """addTrustedSource""": """Which news sources do you want to follow?""",
+      """addSourcePlaceholder""": """Search or enter URL""",
+      """addSourceDescription""": """Search for a source name or its URL""",
+      """btnSave""": """Save""",
+      """trustedSourcesTab""": """Favorite news sources""",
+      """excludedSourcesTab""": """Hidden sources""",
+      """trustedSourcesDescription""":
+          """Add your favorite news outlets to your feed""",
+      """btnAdd""": """Add a news source""",
+      """excludedSourcesDescription""":
+          """These sources will no longer appear in your feed.""",
+      """sourcePendingAddition""": """This source will be added to the list""",
+      """sourcePendingRemoval""":
+          """This source was just removed from the list""",
+      """settingsGiveFeedback""": """Give feedback""",
+      """subscriptionExpiresText""": """The subscription expires on: %s""",
     };

--- a/application/lib/presentation/constants/translations/translations.i18n.yaml
+++ b/application/lib/presentation/constants/translations/translations.i18n.yaml
@@ -174,3 +174,17 @@ subscriptionDurationMonth: month
 takeSurveyTitle: Got a minute?
 takeSurveySubtitle: We'd love your opinion on how to make the app better
 takeSurveyCTA: Take me to the survey
+addExcludedSource: Add a source to exclude it from your feed
+addTrustedSource: Which news sources do you want to follow?
+addSourcePlaceholder: Search or enter URL
+addSourceDescription: Search for a source name or its URL
+btnSave: Save
+trustedSourcesTab: Favorite news sources
+excludedSourcesTab: Hidden sources
+trustedSourcesDescription: Add your favorite news outlets to your feed
+btnAdd: Add a news source
+excludedSourcesDescription: These sources will no longer appear in your feed.
+sourcePendingAddition: This source will be added to the list
+sourcePendingRemoval: This source was just removed from the list
+settingsGiveFeedback: Give feedback
+subscriptionExpiresText: 'The subscription expires on: %s'

--- a/application/lib/presentation/constants/translations/translations_de.i18n.dart
+++ b/application/lib/presentation/constants/translations/translations_de.i18n.dart
@@ -83,9 +83,9 @@ class TranslationsDe extends Translations {
   String get hoursAgo => """hours ago""";
   String get dayAgo => """day ago""";
   String get daysAgo => """days ago""";
-  String get readingTimeUnitSingular => """Min Lesedauer""";
-  String get readingTimeUnitPlural => """Min Lesedauer""";
-  String get readingTimeSuffix => """read""";
+  String get readingTimeUnitSingular => """Min""";
+  String get readingTimeUnitPlural => """Min""";
+  String get readingTimeSuffix => """Lesedauer""";
   String get cannotLoadUrlError => """Unable to load image with url: """;
   String get personalAreaTitle => """Dein Bereich""";
   String get personalAreaCollections => """Deine Collections""";
@@ -230,6 +230,27 @@ class TranslationsDe extends Translations {
   String get takeSurveySubtitle =>
       """Wie können wir Xayn noch besser machen?""";
   String get takeSurveyCTA => """Bring mich zur Umfrage""";
+  String get addExcludedSource =>
+      """Welche Quellen sollen nicht mehr im Feed auftauchen?""";
+  String get addTrustedSource =>
+      """Welchen Quellen möchtest du gerne folgen?""";
+  String get addSourcePlaceholder => """Suchen oder URL eintippen""";
+  String get addSourceDescription =>
+      """Nach Namen oder URL der Quelle suchen""";
+  String get btnSave => """Speichern""";
+  String get trustedSourcesTab => """Lieblingsquellen""";
+  String get excludedSourcesTab => """Verborgene Quellen""";
+  String get trustedSourcesDescription =>
+      """Füge dem Feed Deine Lieblingsquellen hinzu""";
+  String get btnAdd => """Newsquelle hinzufügen""";
+  String get excludedSourcesDescription =>
+      """Diese Quellen werden nicht mehr im Feed angezeigt.""";
+  String get sourcePendingAddition =>
+      """Diese Quelle wird der Liste hinzugefügt""";
+  String get sourcePendingRemoval =>
+      """Diese Quelle wurde gerade aus der Liste entfernt""";
+  String get settingsGiveFeedback => """Give feedback""";
+  String get subscriptionExpiresText => """The subscription expires on: %s""";
 }
 
 class PaymentFlowErrorTranslationsDe extends PaymentFlowErrorTranslations {
@@ -298,9 +319,9 @@ Map<String, String> get translationsDeMap => {
       """hoursAgo""": """hours ago""",
       """dayAgo""": """day ago""",
       """daysAgo""": """days ago""",
-      """readingTimeUnitSingular""": """Min Lesedauer""",
-      """readingTimeUnitPlural""": """Min Lesedauer""",
-      """readingTimeSuffix""": """read""",
+      """readingTimeUnitSingular""": """Min""",
+      """readingTimeUnitPlural""": """Min""",
+      """readingTimeSuffix""": """Lesedauer""",
       """cannotLoadUrlError""": """Unable to load image with url: """,
       """personalAreaTitle""": """Dein Bereich""",
       """personalAreaCollections""": """Deine Collections""",
@@ -459,4 +480,23 @@ Map<String, String> get translationsDeMap => {
       """takeSurveyTitle""": """Hast Du mal 'ne Minute?""",
       """takeSurveySubtitle""": """Wie können wir Xayn noch besser machen?""",
       """takeSurveyCTA""": """Bring mich zur Umfrage""",
+      """addExcludedSource""":
+          """Welche Quellen sollen nicht mehr im Feed auftauchen?""",
+      """addTrustedSource""": """Welchen Quellen möchtest du gerne folgen?""",
+      """addSourcePlaceholder""": """Suchen oder URL eintippen""",
+      """addSourceDescription""": """Nach Namen oder URL der Quelle suchen""",
+      """btnSave""": """Speichern""",
+      """trustedSourcesTab""": """Lieblingsquellen""",
+      """excludedSourcesTab""": """Verborgene Quellen""",
+      """trustedSourcesDescription""":
+          """Füge dem Feed Deine Lieblingsquellen hinzu""",
+      """btnAdd""": """Newsquelle hinzufügen""",
+      """excludedSourcesDescription""":
+          """Diese Quellen werden nicht mehr im Feed angezeigt.""",
+      """sourcePendingAddition""":
+          """Diese Quelle wird der Liste hinzugefügt""",
+      """sourcePendingRemoval""":
+          """Diese Quelle wurde gerade aus der Liste entfernt""",
+      """settingsGiveFeedback""": """Give feedback""",
+      """subscriptionExpiresText""": """The subscription expires on: %s""",
     };

--- a/application/lib/presentation/constants/translations/translations_de.i18n.yaml
+++ b/application/lib/presentation/constants/translations/translations_de.i18n.yaml
@@ -28,9 +28,9 @@ hourAgo: 'hour ago'
 hoursAgo: 'hours ago'
 dayAgo: 'day ago'
 daysAgo: 'days ago'
-readingTimeUnitSingular: 'Min Lesedauer'
-readingTimeUnitPlural: 'Min Lesedauer'
-readingTimeSuffix: 'read'
+readingTimeUnitSingular: 'Min'
+readingTimeUnitPlural: 'Min'
+readingTimeSuffix: 'Lesedauer'
 cannotLoadUrlError: 'Unable to load image with url: '
 personalAreaTitle: Dein Bereich
 personalAreaCollections: Deine Collections
@@ -166,3 +166,17 @@ subscriptionDurationMonth: Monat
 takeSurveyTitle: Hast Du mal 'ne Minute?
 takeSurveySubtitle: Wie können wir Xayn noch besser machen?
 takeSurveyCTA: Bring mich zur Umfrage
+addExcludedSource: Welche Quellen sollen nicht mehr im Feed auftauchen?
+addTrustedSource: Welchen Quellen möchtest du gerne folgen?
+addSourcePlaceholder: Suchen oder URL eintippen
+addSourceDescription: Nach Namen oder URL der Quelle suchen
+btnSave: Speichern
+trustedSourcesTab: Lieblingsquellen
+excludedSourcesTab: Verborgene Quellen
+trustedSourcesDescription: Füge dem Feed Deine Lieblingsquellen hinzu
+btnAdd: Newsquelle hinzufügen
+excludedSourcesDescription: Diese Quellen werden nicht mehr im Feed angezeigt.
+sourcePendingAddition: Diese Quelle wird der Liste hinzugefügt
+sourcePendingRemoval: Diese Quelle wurde gerade aus der Liste entfernt
+settingsGiveFeedback: Give feedback
+subscriptionExpiresText: 'The subscription expires on: %s'

--- a/application/lib/presentation/constants/translations/translations_es.i18n.dart
+++ b/application/lib/presentation/constants/translations/translations_es.i18n.dart
@@ -228,6 +228,26 @@ class TranslationsEs extends Translations {
   String get takeSurveySubtitle =>
       """Nos encantaría tu opinión sobre cómo mejorar la aplicación.""";
   String get takeSurveyCTA => """Llévame a la encuesta""";
+  String get addExcludedSource =>
+      """Agregue una fuente para excluir de tu feed""";
+  String get addTrustedSource =>
+      """Agregue una fuente para incluir en tu feed""";
+  String get addSourcePlaceholder => """Buscar o escribir URL""";
+  String get addSourceDescription =>
+      """Buscar el nombre de una fuente o su URL""";
+  String get btnSave => """Guardar""";
+  String get trustedSourcesTab => """Fuentes incluidas""";
+  String get excludedSourcesTab => """Fuentes excluidas""";
+  String get trustedSourcesDescription =>
+      """Agrega tus fuentes favoritas a tu feed""";
+  String get btnAdd => """Agregar una fuente de noticias""";
+  String get excludedSourcesDescription =>
+      """Las fuentes excluidas ya no aparecerán en su feed.""";
+  String get sourcePendingAddition => """Esta fuente se añadirá a la lista.""";
+  String get sourcePendingRemoval =>
+      """Esta fuente acaba de ser eliminada de la lista.""";
+  String get settingsGiveFeedback => """Give feedback""";
+  String get subscriptionExpiresText => """The subscription expires on: %s""";
 }
 
 class PaymentFlowErrorTranslationsEs extends PaymentFlowErrorTranslations {
@@ -457,4 +477,21 @@ Map<String, String> get translationsEsMap => {
       """takeSurveySubtitle""":
           """Nos encantaría tu opinión sobre cómo mejorar la aplicación.""",
       """takeSurveyCTA""": """Llévame a la encuesta""",
+      """addExcludedSource""": """Agregue una fuente para excluir de tu feed""",
+      """addTrustedSource""": """Agregue una fuente para incluir en tu feed""",
+      """addSourcePlaceholder""": """Buscar o escribir URL""",
+      """addSourceDescription""": """Buscar el nombre de una fuente o su URL""",
+      """btnSave""": """Guardar""",
+      """trustedSourcesTab""": """Fuentes incluidas""",
+      """excludedSourcesTab""": """Fuentes excluidas""",
+      """trustedSourcesDescription""":
+          """Agrega tus fuentes favoritas a tu feed""",
+      """btnAdd""": """Agregar una fuente de noticias""",
+      """excludedSourcesDescription""":
+          """Las fuentes excluidas ya no aparecerán en su feed.""",
+      """sourcePendingAddition""": """Esta fuente se añadirá a la lista.""",
+      """sourcePendingRemoval""":
+          """Esta fuente acaba de ser eliminada de la lista.""",
+      """settingsGiveFeedback""": """Give feedback""",
+      """subscriptionExpiresText""": """The subscription expires on: %s""",
     };

--- a/application/lib/presentation/constants/translations/translations_es.i18n.yaml
+++ b/application/lib/presentation/constants/translations/translations_es.i18n.yaml
@@ -166,3 +166,17 @@ subscriptionDurationMonth: Mes
 takeSurveyTitle: ¿Tienes un minuto?
 takeSurveySubtitle: Nos encantaría tu opinión sobre cómo mejorar la aplicación.
 takeSurveyCTA: Llévame a la encuesta
+addExcludedSource: Agregue una fuente para excluir de tu feed
+addTrustedSource: Agregue una fuente para incluir en tu feed
+addSourcePlaceholder: Buscar o escribir URL
+addSourceDescription: Buscar el nombre de una fuente o su URL
+btnSave: Guardar
+trustedSourcesTab: Fuentes incluidas
+excludedSourcesTab: Fuentes excluidas
+trustedSourcesDescription: Agrega tus fuentes favoritas a tu feed
+btnAdd: Agregar una fuente de noticias
+excludedSourcesDescription: Las fuentes excluidas ya no aparecerán en su feed.
+sourcePendingAddition: Esta fuente se añadirá a la lista.
+sourcePendingRemoval: Esta fuente acaba de ser eliminada de la lista.
+settingsGiveFeedback: Give feedback
+subscriptionExpiresText: 'The subscription expires on: %s'

--- a/application/lib/presentation/constants/translations/translations_fr.i18n.dart
+++ b/application/lib/presentation/constants/translations/translations_fr.i18n.dart
@@ -233,6 +233,27 @@ class TranslationsFr extends Translations {
   String get takeSurveySubtitle =>
       """Comment pouvons-nous encore améliorer Xayn ?""";
   String get takeSurveyCTA => """Emmenez-moi à l'enquête""";
+  String get addExcludedSource =>
+      """Ajouter une source à exclure de votre flux""";
+  String get addTrustedSource =>
+      """Ajouter une source à inclure dans votre flux""";
+  String get addSourcePlaceholder => """Rechercher ou saisir l'URL""";
+  String get addSourceDescription =>
+      """Rechercher un nom de source ou une URL""";
+  String get btnSave => """Sauvegarder""";
+  String get trustedSourcesTab => """Sources préférées""";
+  String get excludedSourcesTab => """Sources exclues""";
+  String get trustedSourcesDescription =>
+      """Ajoutez vos sources préférées à votre flux""";
+  String get btnAdd => """Ajouter une source d'actualités""";
+  String get excludedSourcesDescription =>
+      """Sources exclues n'apparaîtront plus dans votre flux.""";
+  String get sourcePendingAddition =>
+      """Cette source sera ajoutée à la liste""";
+  String get sourcePendingRemoval =>
+      """Cette source vient d'être supprimée de la liste""";
+  String get settingsGiveFeedback => """Give feedback""";
+  String get subscriptionExpiresText => """The subscription expires on: %s""";
 }
 
 class PaymentFlowErrorTranslationsFr extends PaymentFlowErrorTranslations {
@@ -464,4 +485,22 @@ Map<String, String> get translationsFrMap => {
       """takeSurveySubtitle""":
           """Comment pouvons-nous encore améliorer Xayn ?""",
       """takeSurveyCTA""": """Emmenez-moi à l'enquête""",
+      """addExcludedSource""": """Ajouter une source à exclure de votre flux""",
+      """addTrustedSource""":
+          """Ajouter une source à inclure dans votre flux""",
+      """addSourcePlaceholder""": """Rechercher ou saisir l'URL""",
+      """addSourceDescription""": """Rechercher un nom de source ou une URL""",
+      """btnSave""": """Sauvegarder""",
+      """trustedSourcesTab""": """Sources préférées""",
+      """excludedSourcesTab""": """Sources exclues""",
+      """trustedSourcesDescription""":
+          """Ajoutez vos sources préférées à votre flux""",
+      """btnAdd""": """Ajouter une source d'actualités""",
+      """excludedSourcesDescription""":
+          """Sources exclues n'apparaîtront plus dans votre flux.""",
+      """sourcePendingAddition""": """Cette source sera ajoutée à la liste""",
+      """sourcePendingRemoval""":
+          """Cette source vient d'être supprimée de la liste""",
+      """settingsGiveFeedback""": """Give feedback""",
+      """subscriptionExpiresText""": """The subscription expires on: %s""",
     };

--- a/application/lib/presentation/constants/translations/translations_fr.i18n.yaml
+++ b/application/lib/presentation/constants/translations/translations_fr.i18n.yaml
@@ -166,3 +166,17 @@ subscriptionDurationMonth: Mois
 takeSurveyTitle: Avez-vous une minute ?
 takeSurveySubtitle: Comment pouvons-nous encore améliorer Xayn ?
 takeSurveyCTA: Emmenez-moi à l'enquête
+addExcludedSource: Ajouter une source à exclure de votre flux
+addTrustedSource: Ajouter une source à inclure dans votre flux
+addSourcePlaceholder: Rechercher ou saisir l'URL
+addSourceDescription: Rechercher un nom de source ou une URL
+btnSave: Sauvegarder
+trustedSourcesTab: Sources préférées
+excludedSourcesTab: Sources exclues
+trustedSourcesDescription: Ajoutez vos sources préférées à votre flux
+btnAdd: Ajouter une source d'actualités
+excludedSourcesDescription: Sources exclues n'apparaîtront plus dans votre flux.
+sourcePendingAddition: Cette source sera ajoutée à la liste
+sourcePendingRemoval: Cette source vient d'être supprimée de la liste
+settingsGiveFeedback: Give feedback
+subscriptionExpiresText: 'The subscription expires on: %s'

--- a/application/lib/presentation/constants/translations/translations_nl.i18n.dart
+++ b/application/lib/presentation/constants/translations/translations_nl.i18n.dart
@@ -226,6 +226,26 @@ class TranslationsNl extends Translations {
   String get takeSurveyTitle => """Heb je even?""";
   String get takeSurveySubtitle => """Hoe kunnen we Xayn nog beter maken?""";
   String get takeSurveyCTA => """Breng me naar de enquête""";
+  String get addExcludedSource =>
+      """Voeg bronnen toe die je liever niet ziet in je feed""";
+  String get addTrustedSource =>
+      """Voeg bronnen toe die je uitdrukkelijk wil zien in je feed""";
+  String get addSourcePlaceholder => """Zoek of typ de URL""";
+  String get addSourceDescription => """Zoek naar een naam of de URL ervan""";
+  String get btnSave => """Opslaan""";
+  String get trustedSourcesTab => """Inbegrepen bronnen""";
+  String get excludedSourcesTab => """Uitgesloten bronnen""";
+  String get trustedSourcesDescription =>
+      """Voeg je favoriete bronnen toe aan je feed""";
+  String get btnAdd => """Nieuwsbron toevoegen""";
+  String get excludedSourcesDescription =>
+      """Uitgesloten bronnen verschijnen niet meer in uw feed.""";
+  String get sourcePendingAddition =>
+      """Deze bron wordt toegevoegd aan de lijst""";
+  String get sourcePendingRemoval =>
+      """Deze bron is zojuist van de lijst verwijderd""";
+  String get settingsGiveFeedback => """Give feedback""";
+  String get subscriptionExpiresText => """The subscription expires on: %s""";
 }
 
 class PaymentFlowErrorTranslationsNl extends PaymentFlowErrorTranslations {
@@ -451,4 +471,24 @@ Map<String, String> get translationsNlMap => {
       """takeSurveyTitle""": """Heb je even?""",
       """takeSurveySubtitle""": """Hoe kunnen we Xayn nog beter maken?""",
       """takeSurveyCTA""": """Breng me naar de enquête""",
+      """addExcludedSource""":
+          """Voeg bronnen toe die je liever niet ziet in je feed""",
+      """addTrustedSource""":
+          """Voeg bronnen toe die je uitdrukkelijk wil zien in je feed""",
+      """addSourcePlaceholder""": """Zoek of typ de URL""",
+      """addSourceDescription""": """Zoek naar een naam of de URL ervan""",
+      """btnSave""": """Opslaan""",
+      """trustedSourcesTab""": """Inbegrepen bronnen""",
+      """excludedSourcesTab""": """Uitgesloten bronnen""",
+      """trustedSourcesDescription""":
+          """Voeg je favoriete bronnen toe aan je feed""",
+      """btnAdd""": """Nieuwsbron toevoegen""",
+      """excludedSourcesDescription""":
+          """Uitgesloten bronnen verschijnen niet meer in uw feed.""",
+      """sourcePendingAddition""":
+          """Deze bron wordt toegevoegd aan de lijst""",
+      """sourcePendingRemoval""":
+          """Deze bron is zojuist van de lijst verwijderd""",
+      """settingsGiveFeedback""": """Give feedback""",
+      """subscriptionExpiresText""": """The subscription expires on: %s""",
     };

--- a/application/lib/presentation/constants/translations/translations_nl.i18n.yaml
+++ b/application/lib/presentation/constants/translations/translations_nl.i18n.yaml
@@ -166,3 +166,17 @@ subscriptionDurationMonth: Maand
 takeSurveyTitle: Heb je even?
 takeSurveySubtitle: Hoe kunnen we Xayn nog beter maken?
 takeSurveyCTA: Breng me naar de enquête
+addExcludedSource: Voeg bronnen toe die je liever niet ziet in je feed
+addTrustedSource: Voeg bronnen toe die je uitdrukkelijk wil zien in je feed
+addSourcePlaceholder: Zoek of typ de URL
+addSourceDescription: Zoek naar een naam of de URL ervan
+btnSave: Opslaan
+trustedSourcesTab: Inbegrepen bronnen
+excludedSourcesTab: Uitgesloten bronnen
+trustedSourcesDescription: Voeg je favoriete bronnen toe aan je feed
+btnAdd: Nieuwsbron toevoegen
+excludedSourcesDescription: Uitgesloten bronnen verschijnen niet meer in uw feed.
+sourcePendingAddition: Deze bron wordt toegevoegd aan de lijst
+sourcePendingRemoval: Deze bron is zojuist van de lijst verwijderd
+settingsGiveFeedback: Give feedback
+subscriptionExpiresText: 'The subscription expires on: %s'

--- a/application/lib/presentation/constants/translations/translations_pl.i18n.dart
+++ b/application/lib/presentation/constants/translations/translations_pl.i18n.dart
@@ -180,7 +180,7 @@ class TranslationsPl extends Translations {
   String get errorGenericHeaderSomethingWentWrong => """Coś poszło nie tak""";
   String get errorGenericBodyPleaseTryAgainLater =>
       """Spróbuj ponownie później.""";
-  String get errorClose => """Blisko""";
+  String get errorClose => """Zamknij""";
   String get sourceHandlingTooltipLabel => """Czego chcesz mniej widzieć?""";
   String get sourceHandlingTooltipHighlightedWord => """Co""";
   String get enableTextToSpeech => """Włącz zamianę tekstu na mowę""";
@@ -226,6 +226,26 @@ class TranslationsPl extends Translations {
   String get takeSurveySubtitle =>
       """Jak możemy jeszcze bardziej ulepszyć Xayn?""";
   String get takeSurveyCTA => """Zabierz mnie do ankiety""";
+  String get addExcludedSource =>
+      """Dodaj źródło do wykluczenia z pliku danych""";
+  String get addTrustedSource =>
+      """Which news sources do you want to follow?""";
+  String get addSourcePlaceholder => """Wyszukaj lub wpisz adres URL""";
+  String get addSourceDescription =>
+      """Wyszukaj nazwę źródła lub jego adres URL""";
+  String get btnSave => """Zapisać""";
+  String get trustedSourcesTab => """Favorite news sources""";
+  String get excludedSourcesTab => """Hidden sources""";
+  String get trustedSourcesDescription =>
+      """Dodaj swoje ulubione źródła do swojego kanału""";
+  String get btnAdd => """Dodaj źródło wiadomości""";
+  String get excludedSourcesDescription =>
+      """Wykluczone źródła nie będą już pojawiać się w Twoim kanale.""";
+  String get sourcePendingAddition => """To źródło zostanie dodane do listy""";
+  String get sourcePendingRemoval =>
+      """To źródło zostało właśnie usunięte z listy""";
+  String get settingsGiveFeedback => """Give feedback""";
+  String get subscriptionExpiresText => """Subskrypcja wygasa w dniu: %s""";
 }
 
 class PaymentFlowErrorTranslationsPl extends PaymentFlowErrorTranslations {
@@ -261,7 +281,7 @@ class OnboardingBottomDialogTranslationsPl
 class GeneralTranslationsPl extends GeneralTranslations {
   final TranslationsPl _parent;
   const GeneralTranslationsPl(this._parent) : super(_parent);
-  String get btnClose => """Zakończyć""";
+  String get btnClose => """Zamknij""";
 }
 
 Map<String, String> get translationsPlMap => {
@@ -397,7 +417,7 @@ Map<String, String> get translationsPlMap => {
       """errorGenericHeaderSomethingWentWrong""": """Coś poszło nie tak""",
       """errorGenericBodyPleaseTryAgainLater""":
           """Spróbuj ponownie później.""",
-      """errorClose""": """Blisko""",
+      """errorClose""": """Zamknij""",
       """sourceHandlingTooltipLabel""": """Czego chcesz mniej widzieć?""",
       """sourceHandlingTooltipHighlightedWord""": """Co""",
       """enableTextToSpeech""": """Włącz zamianę tekstu na mowę""",
@@ -446,10 +466,28 @@ Map<String, String> get translationsPlMap => {
       """onboardingBottomDialog.bookmarksManageTitle""":
           """Naciśnij i przytrzymaj, aby zarządzać zakładkami""",
       """onboardingBottomDialog.cancelButton""": """Rozumiem!""",
-      """general.btnClose""": """Zakończyć""",
+      """general.btnClose""": """Zamknij""",
       """subscriptionDurationMonth""": """miesiąc""",
       """takeSurveyTitle""": """Masz minutkę?""",
       """takeSurveySubtitle""":
           """Jak możemy jeszcze bardziej ulepszyć Xayn?""",
       """takeSurveyCTA""": """Zabierz mnie do ankiety""",
+      """addExcludedSource""": """Dodaj źródło do wykluczenia z pliku danych""",
+      """addTrustedSource""": """Which news sources do you want to follow?""",
+      """addSourcePlaceholder""": """Wyszukaj lub wpisz adres URL""",
+      """addSourceDescription""":
+          """Wyszukaj nazwę źródła lub jego adres URL""",
+      """btnSave""": """Zapisać""",
+      """trustedSourcesTab""": """Favorite news sources""",
+      """excludedSourcesTab""": """Hidden sources""",
+      """trustedSourcesDescription""":
+          """Dodaj swoje ulubione źródła do swojego kanału""",
+      """btnAdd""": """Dodaj źródło wiadomości""",
+      """excludedSourcesDescription""":
+          """Wykluczone źródła nie będą już pojawiać się w Twoim kanale.""",
+      """sourcePendingAddition""": """To źródło zostanie dodane do listy""",
+      """sourcePendingRemoval""":
+          """To źródło zostało właśnie usunięte z listy""",
+      """settingsGiveFeedback""": """Give feedback""",
+      """subscriptionExpiresText""": """Subskrypcja wygasa w dniu: %s""",
     };

--- a/application/lib/presentation/constants/translations/translations_pl.i18n.yaml
+++ b/application/lib/presentation/constants/translations/translations_pl.i18n.yaml
@@ -123,7 +123,7 @@ bottomSheetMoveSingleBookmark: Przejdź do innej kolekcji
 readerModeSettingsErrorChangesNotApplied: Nie udało się zastosować zmian
 errorGenericHeaderSomethingWentWrong: Coś poszło nie tak
 errorGenericBodyPleaseTryAgainLater: Spróbuj ponownie później.
-errorClose: Blisko
+errorClose: Zamknij
 sourceHandlingTooltipLabel: Czego chcesz mniej widzieć?
 sourceHandlingTooltipHighlightedWord: Co
 enableTextToSpeech: Włącz zamianę tekstu na mowę
@@ -161,8 +161,22 @@ onboardingBottomDialog:
   bookmarksManageTitle: Naciśnij i przytrzymaj, aby zarządzać zakładkami
   cancelButton: Rozumiem!
 general:
-  btnClose: Zakończyć
+  btnClose: Zamknij
 subscriptionDurationMonth: miesiąc
 takeSurveyTitle: Masz minutkę?
 takeSurveySubtitle: Jak możemy jeszcze bardziej ulepszyć Xayn?
 takeSurveyCTA: Zabierz mnie do ankiety
+addExcludedSource: Dodaj źródło do wykluczenia z pliku danych
+addTrustedSource: Which news sources do you want to follow?
+addSourcePlaceholder: Wyszukaj lub wpisz adres URL
+addSourceDescription: Wyszukaj nazwę źródła lub jego adres URL
+btnSave: Zapisać
+trustedSourcesTab: Favorite news sources
+excludedSourcesTab: Hidden sources
+trustedSourcesDescription: Dodaj swoje ulubione źródła do swojego kanału
+btnAdd: Dodaj źródło wiadomości
+excludedSourcesDescription: Wykluczone źródła nie będą już pojawiać się w Twoim kanale.
+sourcePendingAddition: To źródło zostanie dodane do listy
+sourcePendingRemoval: To źródło zostało właśnie usunięte z listy
+settingsGiveFeedback: Give feedback
+subscriptionExpiresText: 'Subskrypcja wygasa w dniu: %s'

--- a/application/lib/presentation/premium/widgets/subscription_details_bottom_sheet.dart
+++ b/application/lib/presentation/premium/widgets/subscription_details_bottom_sheet.dart
@@ -71,7 +71,9 @@ class _SubscriptionDetails extends StatelessWidget with BottomSheetBodyMixin {
 
   Widget _buildInfo() {
     final dateString = subscriptionStatus.expirationDate?.shortDateFormat ?? '';
-    final infoString = R.strings.subscriptionRenewsMonthlyText;
+    final infoString = subscriptionStatus.willRenew
+        ? R.strings.subscriptionRenewsMonthlyText
+        : R.strings.subscriptionExpiresText;
     final infoStringWithDate =
         infoString.format('$_kTextPlaceholder$dateString$_kTextPlaceholder');
     return SuperRichText(

--- a/application/test/infrastructure/use_case/payment/get_subscription_status_use_case_test.dart
+++ b/application/test/infrastructure/use_case/payment/get_subscription_status_use_case_test.dart
@@ -35,7 +35,7 @@ void main() {
       // ASSERT
       expect(subscriptionStatus.isSubscriptionActive, isTrue);
       expect(subscriptionStatus.isFreeTrialActive, isFalse);
-      expect(subscriptionStatus.willRenew, isTrue);
+      expect(subscriptionStatus.willRenew, isFalse);
       expect(subscriptionStatus.expirationDate, isNotNull);
       expect(subscriptionStatus.trialEndDate, isNotNull);
       verify(paymentService.getPurchaserInfo());


### PR DESCRIPTION
### What 🕵️ 🔍

This PR fixes an issue where we didn't check if the subscription will renew to display the subscription info text. It was always saying that it renews, even though it could expire (promo code or the user cancelled subscription).

----------

### How to test  🥼 🔬
This can be only verified on production.

When testing on internal builds:
- Enable payment feature flag
- Tap on the trial banner
- The willRenew flag will be set randomly (the text will say renew or expire)
- Repeat the process to test the other scenario

----------

### Screenshots 📸 📱

| Before | After  |
| ------ | ------ |
| <img width="280" src="https://user-images.githubusercontent.com/17122295/175244734-399e366e-65d6-4750-9f21-c598736dd2be.png"> | <img width="280" src="https://user-images.githubusercontent.com/17122295/175244780-52d65a40-73a2-405b-add2-799d02be05ad.png"> |

----------

### References 📝 🔗

- [JIRA](https://xainag.atlassian.net/browse/TB-3899)

----------