### PR TITLE
TB-3992: Fix sometimes transparent image in feeds

### DIFF
--- a/application/lib/presentation/discovery_card/widget/discovery_card_base.dart
+++ b/application/lib/presentation/discovery_card/widget/discovery_card_base.dart
@@ -171,6 +171,8 @@ abstract class DiscoveryCardBaseState<T extends DiscoveryCardBase>
       );
     }
 
+    if (webResource.image == null) return getDeterministicNoImage();
+
     return CachedImage(
       imageManager: imageManager,
       shaderBuilder: widget.primaryCardShader,


### PR DESCRIPTION
### What 🕵️ 🔍

Sometimes, an image is shown as completely transparent.
This happens when there is a null image returning from NewsCatcher's api

This PR fixes it by showing the "no-image" instead

----------

### How to test (please adjust template) 🥼 🔬
- Feed:
  - [x] Verify that transparent images no longer happen

----------

### Screenshots 📸 📱

| Before | After  |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/3460003/176275158-1929764a-bcde-4d80-994f-8f6dde3f1d8a.png) | ![image](https://user-images.githubusercontent.com/3460003/176275096-126111d9-d4b4-4da1-ab07-b0321ca6f1e2.png) |

----------

### References 📝 🔗

- [TB-3992](https://xainag.atlassian.net/browse/TB-3992)

----------