### PR TITLE
Tb 3999 Hide menu dialog when scrolling outside

### DIFF
--- a/application/lib/presentation/discovery_card/widget/discovery_card_header_menu.dart
+++ b/application/lib/presentation/discovery_card/widget/discovery_card_header_menu.dart
@@ -19,7 +19,9 @@ class DiscoveryCardHeaderMenu extends StatelessWidget {
       start: R.dimen.unit4,
       width: R.dimen.screenWidth - R.dimen.unit8,
       borderRadius: R.styles.roundBorder3,
-      onClose: onClose,
+      onTapOutside: onClose,
+      onDragOutside: onClose,
+      onPop: onClose,
       child: _buildMenuBody(items),
     );
   }

--- a/application/lib/presentation/menu/edit_reader_mode_settings/widget/edit_reader_mode_settings.dart
+++ b/application/lib/presentation/menu/edit_reader_mode_settings/widget/edit_reader_mode_settings.dart
@@ -94,7 +94,8 @@ class _EditReaderModeSettingsMenuState
               R.dimen.unit4_25,
           end: R.dimen.unit2,
           width: R.dimen.unit22,
-          onClose: widget.onCloseMenu,
+          onTapOutside: widget.onCloseMenu,
+          onPop: widget.onCloseMenu,
           errorMessage: state.error != null
               ? R.strings.readerModeSettingsErrorChangesNotApplied
               : null,

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -88,7 +88,7 @@ dependencies:
   xayn_design:
     git:
       url: git@github.com:xaynetwork/xayn_design.git
-      ref: 778b1e541d4807d8394552dd0e61ed20606dab8e
+      ref: fc82e224320f24e88eaa6c26f1d003057d479a9c
   xayn_discovery_engine_flutter:
     git:
       url: https://gitlab.com/xayn/xayn_discovery_engine_release


### PR DESCRIPTION
### What 🕵️ 🔍

- What exactly was added or modified?
Hides the card header menu dialog when scrolling outside

----------

### How to test (please adjust template) 🥼 🔬
- Feature flag enabled:
  Test main feature, and verify that all aspects of the story are working as described in the PR and the Jira story
  - [ ] Open the menu dialog by tapping the menu icon (3 dots) in the card header
  - [ ] Scroll outside, in any direction, and check that the menu dialog is being hidden
  - [ ] Check that the menu dialog for changing reader mode settings work as expected
  
- Feature flag disabled:
  - [ ] Check that the menu dialog for changing reader mode settings work as expected


- Feature affects new Engine/ Card manager / Settings / DB changes / Architecture update
  - Go to Setting, change language :
    - [ ] Verify that the Feed shows articles in the new language
    - [ ] Verify that like/ dislike / bookmark, visually works
    - [ ] Verify that articles show up in bookmarks
    - [ ] Verify search works and articles show up in the new language

- Feature has DB change
  - [ ] Upgrade test from previous version, verify that the app starts and that the affected area works as expected

- Feature affects platform dependent code
  - [ ] Verify feature on iOS
  - [ ] Verify feature on Android

- Feature affects UI changes
  - [ ] Verify on iPhone SE / [Small Android]
  - [ ] (default) Verify on Pro 13 Max / (Big Android)

----------

### Screenshots 📸 📱

| Demo |
| ------------ |
| <video width="280" src="https://user-images.githubusercontent.com/74236996/176729191-3ed1b2a0-03e8-4608-99e6-823c44a27a9d.mov"> |


----------

### References 📝 🔗

- [JIRA](https://xainag.atlassian.net/browse/TB-3999)

----------