### PR TITLE
Fix CI not showing failing tests

### DIFF
--- a/application/fastlane/Fastfile
+++ b/application/fastlane/Fastfile
@@ -256,17 +256,17 @@ lane :check do |options|
     # Creates a fake test that imports all files so that lcov calculates the correct coverage
     shell('find lib ! -name "*.freezed.dart" ! -name "*.config.dart" ! -name "*.g.dart" ! -name "generated_plugin_registrant.dart"  -name *.dart  | sed \'s/lib\///\' | sed  \'s/.*/import "package:xayn_discovery_app\/&";/\' > test/all_imports_test.dart')
     shell("cat test/test_stub.dart >> test/all_imports_test.dart")
-    flutter(args: %W(test --coverage --reporter=json > machine.log || echo 'Tests failed'))
+    shell("flutter test --coverage --reporter=json > machine.log || echo 'Tests failed'")
     lcov_ignore_rules = shell("cat lcov_ignore | grep -v \\# | tr '\n' ' '")
     shell("mv coverage/lcov.info coverage/original_lcov.info")
     shell("lcov --remove coverage/original_lcov.info #{lcov_ignore_rules} -o coverage/lcov.info")
     shell("genhtml coverage/lcov.info -o coverage/html")
   else
-    machine_log = flutter(args: %W(test --reporter=json), capture_stdout: true)
-    File.write("../machine.log", machine_log)
+      shell("flutter test --reporter=json > machine.log || echo 'Tests failed'")
   end
+
   begin
-    flutter(args: %W(pub global run dart_dot_reporter machine.log --show-message))
+    shell("flutter pub global run dart_dot_reporter machine.log --show-message")
   rescue
     UI.user_error!("Checks failed!")
   end


### PR DESCRIPTION
### What 🕵️ 🔍

Fastlane plugin 'fastlane-plugin-flutter' doesn't work well with failure in `flutter test` output report. The report is only output when `flutter test` passes. This PR refactors our dependency on the fastlane plugin to a normal shell command.

----------

### How to test  🥼 🔬
  - [ ] Run `fastlane check` command
  - [ ] Edit a test locally so it fails
  - [ ] Run `fastlane check` command again

----------