### PR TITLE
TB-4012 Use root overlay when showing the discovery card menu dialog

### DIFF
--- a/application/lib/presentation/active_search/widget/active_search.dart
+++ b/application/lib/presentation/active_search/widget/active_search.dart
@@ -100,7 +100,7 @@ class _ActiveSearchState
           );
 
       void onEditReaderModeSettingsPressed() => toggleOverlay(
-            (_) => EditReaderModeSettingsMenu(
+            builder: (_) => EditReaderModeSettingsMenu(
               onCloseMenu: removeOverlay,
             ),
           );

--- a/application/lib/presentation/discovery_card/screen/discovery_card_screen.dart
+++ b/application/lib/presentation/discovery_card/screen/discovery_card_screen.dart
@@ -129,7 +129,7 @@ class _DiscoveryCardScreenState extends State<DiscoveryCardScreen>
 
   void onEditReaderModeSettingsPressed() {
     toggleOverlay(
-      (_) => EditReaderModeSettingsMenu(
+      builder: (_) => EditReaderModeSettingsMenu(
         onCloseMenu: removeOverlay,
       ),
     );

--- a/application/lib/presentation/discovery_card/widget/dicovery_feed_card.dart
+++ b/application/lib/presentation/discovery_card/widget/dicovery_feed_card.dart
@@ -61,11 +61,12 @@ class _DiscoveryFeedCardState extends DiscoveryCardBaseState<DiscoveryFeedCard>
         widget.onTtsData?.call(TtsData.disabled());
 
         toggleOverlay(
-          (_) => DiscoveryCardHeaderMenu(
+          builder: (_) => DiscoveryCardHeaderMenu(
             itemsMap: _buildDiscoveryCardHeaderMenuItems,
             source: Source.fromJson(widget.document.resource.url.host),
             onClose: removeOverlay,
           ),
+          useRootOverlay: true,
         );
       },
       onProviderSectionTap: () {

--- a/application/lib/presentation/discovery_card/widget/discovery_card.dart
+++ b/application/lib/presentation/discovery_card/widget/discovery_card.dart
@@ -200,11 +200,12 @@ class _DiscoveryCardState extends DiscoveryCardBaseState<DiscoveryCard>
             widget.onTtsData?.call(TtsData.disabled());
 
             toggleOverlay(
-              (_) => DiscoveryCardHeaderMenu(
+              builder: (_) => DiscoveryCardHeaderMenu(
                 itemsMap: _buildDiscoveryCardHeaderMenuItems,
                 source: Source.fromJson(widget.document.resource.url.host),
                 onClose: removeOverlay,
               ),
+              useRootOverlay: true,
             );
           },
           onProviderSectionTap: () {

--- a/application/lib/presentation/discovery_card/widget/discovery_card_static.dart
+++ b/application/lib/presentation/discovery_card/widget/discovery_card_static.dart
@@ -88,11 +88,12 @@ class _DiscoveryCardStaticState
             widget.onTtsData?.call(TtsData.disabled());
 
             toggleOverlay(
-              (_) => DiscoveryCardHeaderMenu(
+              builder: (_) => DiscoveryCardHeaderMenu(
                 itemsMap: _buildDiscoveryCardHeaderMenuItems,
                 source: Source.fromJson(widget.document.resource.url.host),
                 onClose: removeOverlay,
               ),
+              useRootOverlay: true,
             );
           },
           onProviderSectionTap: () {

--- a/application/lib/presentation/discovery_feed/widget/discovery_feed.dart
+++ b/application/lib/presentation/discovery_feed/widget/discovery_feed.dart
@@ -68,7 +68,7 @@ class _DiscoveryFeedState
 
       void onEditReaderModeSettingsPressed() {
         toggleOverlay(
-          (_) => EditReaderModeSettingsMenu(
+          builder: (_) => EditReaderModeSettingsMenu(
             onCloseMenu: removeOverlay,
           ),
         );

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -95,7 +95,7 @@ dependencies:
   xayn_design:
     git:
       url: git@github.com:xaynetwork/xayn_design.git
-      ref: d4a509f0dbc7a775e0461f303abc231d42b2983a
+      ref: 1d700cb37c2c7e16b57a422a52cf00aa683630ee
   xayn_discovery_engine_flutter:
     git:
       url: https://gitlab.com/xayn/xayn_discovery_engine_release


### PR DESCRIPTION
### What 🕵️ 🔍

- What does the pull request solve?
While the menu is opened, tapping on the navBar was not hiding it
- What exactly was added or modified?
Uses the root overlay when showing the discovery card menu dialog

----------

### How to test (please adjust template) 🥼 🔬
- Feature flag enabled:
  Test main feature, and verify that all aspects of the story are working as described in the PR and the Jira story
  - [ ] Open the discovery card menu dialog
  - [ ] Tap on any icon of the navBar. Check that the menu is being hidden and nothing else happens

----------

### Screenshots 📸 📱

| Demo |
<video width="280" src="https://user-images.githubusercontent.com/74236996/177376226-0de7f91e-3576-4ec7-a2e7-3df5347f5993.mov"> 

----------





### References 📝 🔗

- [JIRA](https://xainag.atlassian.net/browse/TB-4012)

----------