### PR TITLE
TB-4013 Adjust menu dialog top padding

### DIFF
--- a/application/lib/presentation/discovery_card/widget/discovery_card_header_menu.dart
+++ b/application/lib/presentation/discovery_card/widget/discovery_card_header_menu.dart
@@ -31,8 +31,10 @@ class DiscoveryCardHeaderMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final topPadding = MediaQuery.of(context).viewPadding.top;
+
     return AppMenu.single(
-      top: R.dimen.unit15,
+      top: topPadding + R.dimen.cardNotchSize + R.dimen.unit,
       start: R.dimen.unit4,
       width: R.dimen.screenWidth - R.dimen.unit8,
       borderRadius: R.styles.roundBorder3,


### PR DESCRIPTION
### What 🕵️ 🔍

- What does the pull request solve?
Adjusts the menu dialog top padding. It seemed to be too far from the card header compare with the distance shown in figma

----------

### How to test (please adjust template) 🥼 🔬
- Feature flag enabled:
  Test main feature, and verify that all aspects of the story are working as described in the PR and the Jira story
  - [x] Open the menu and check that the padding is similar to the one shown in figma

----------

### Screenshots 📸 📱

| Before | After  |
| ------ | ------ |
| <img width="280" src="https://user-images.githubusercontent.com/74236996/177557690-d3e3a6f0-3cc0-44ef-ac51-cf2227a2ee2b.png"> | <img width="280" src="https://user-images.githubusercontent.com/74236996/177557474-2eef6b1c-32bb-4a9f-a8e4-8674b143fb22.png"> |

----------

### References 📝 🔗

- [JIRA](https://xainag.atlassian.net/browse/TB-4013)
- [FIGMA](https://www.figma.com/file/hGAst3K9ZQIHmQoCNjbgaZ/Discovery-App-%7C-Design?node-id=391%3A1139)

----------