### PR TITLE
TB-4025 Implement UI for resetting ai option

### DIFF
--- a/application/bin/create_snapshot.dart
+++ b/application/bin/create_snapshot.dart
@@ -156,6 +156,8 @@ void _createDocuments() {
       score: .0,
       topic: 'topic',
     ),
+    // ignore: invalid_use_of_visible_for_testing_member
+    stackId: StackId.nil(),
   );
   final documentWrapper = DocumentWrapper(document);
   repository.save(documentWrapper);

--- a/application/lib/domain/model/feature.dart
+++ b/application/lib/domain/model/feature.dart
@@ -22,7 +22,13 @@ enum Feature {
     'Open menu when clicking card header icon',
   ),
   pushNotificationDeepLinks(Owner.Peter, EnvironmentHelper.kIsDebug,
-      'Allows to deep link to an article when tapping on push notification');
+      'Allows to deep link to an article when tapping on push notification'),
+
+  resetAI(
+    Owner.Carmine,
+    EnvironmentHelper.kIsDebug || EnvironmentHelper.kIsInternalFlavor,
+    'Shows the reset AI option in the settings screen',
+  );
 
   final Owner owner;
   final String? description;

--- a/application/lib/infrastructure/discovery_engine/app_discovery_engine.dart
+++ b/application/lib/infrastructure/discovery_engine/app_discovery_engine.dart
@@ -21,6 +21,9 @@ import 'package:xayn_discovery_engine_flutter/discovery_engine.dart';
 const int _kSearchPageSize = 20;
 const int _kFeedBatchSize = 2;
 
+const String _kHeadlinesProviderPath = '/newscatcher/v1/latest-headlines';
+const String _kNewsProviderPath = '/newscatcher/v1/search-news';
+
 /// A wrapper for the [DiscoveryEngine].
 @LazySingleton(as: DiscoveryEngine)
 class AppDiscoveryEngine with AsyncInitMixin implements DiscoveryEngine {
@@ -99,6 +102,8 @@ class AppDiscoveryEngine with AsyncInitMixin implements DiscoveryEngine {
       maxItemsPerSearchBatch: _kSearchPageSize,
       feedMarkets: feedMarkets,
       manifest: manifest,
+      headlinesProviderPath: _kHeadlinesProviderPath,
+      newsProviderPath: _kNewsProviderPath,
     );
 
     _updateFeedMarketIdentityParam(feedMarkets);

--- a/application/lib/infrastructure/discovery_engine/use_case/reset_ai_use_case.dart
+++ b/application/lib/infrastructure/discovery_engine/use_case/reset_ai_use_case.dart
@@ -1,0 +1,15 @@
+import 'package:injectable/injectable.dart';
+import 'package:xayn_architecture/xayn_architecture.dart';
+import 'package:xayn_discovery_engine_flutter/discovery_engine.dart';
+
+@injectable
+class ResetAIUseCase extends UseCase<None, EngineEvent> {
+  final DiscoveryEngine _engine;
+
+  ResetAIUseCase(this._engine);
+
+  @override
+  Stream<EngineEvent> transaction(None param) async* {
+    yield await _engine.resetAi();
+  }
+}

--- a/application/lib/infrastructure/discovery_engine/use_case/reset_ai_use_case.dart
+++ b/application/lib/infrastructure/discovery_engine/use_case/reset_ai_use_case.dart
@@ -2,14 +2,22 @@ import 'package:injectable/injectable.dart';
 import 'package:xayn_architecture/xayn_architecture.dart';
 import 'package:xayn_discovery_engine_flutter/discovery_engine.dart';
 
+///Return true if succeeded, false otherwise
+///
 @injectable
-class ResetAIUseCase extends UseCase<None, EngineEvent> {
+class ResetAIUseCase extends UseCase<None, bool> {
   final DiscoveryEngine _engine;
 
   ResetAIUseCase(this._engine);
 
   @override
-  Stream<EngineEvent> transaction(None param) async* {
-    yield await _engine.resetAi();
+  Stream<bool> transaction(None param) async* {
+    final engineEvent = await _engine.resetAi();
+    if (engineEvent is ResetAiSucceeded) {
+      yield true;
+      return;
+    } else {
+      yield false;
+    }
   }
 }

--- a/application/lib/presentation/bottom_sheet/reset_ai/manager/resetting_ai_manager.dart
+++ b/application/lib/presentation/bottom_sheet/reset_ai/manager/resetting_ai_manager.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+import 'package:xayn_architecture/xayn_architecture.dart';
+import 'package:xayn_discovery_app/infrastructure/discovery_engine/use_case/reset_ai_use_case.dart';
+import 'package:xayn_discovery_app/presentation/bottom_sheet/reset_ai/manager/resetting_ai_state.dart';
+import 'package:xayn_discovery_app/presentation/discovery_feed/manager/discovery_feed_manager.dart';
+import 'package:xayn_discovery_app/presentation/utils/overlay/overlay_manager_mixin.dart';
+import 'package:xayn_discovery_engine_flutter/discovery_engine.dart';
+
+@injectable
+class ResettingAIManager extends Cubit<ResettingAIState>
+    with
+        UseCaseBlocHelper<ResettingAIState>,
+        OverlayManagerMixin<ResettingAIState> {
+  final ResetAIUseCase resetAIUseCase;
+  final DiscoveryFeedManager discoveryFeedManager;
+
+  ResettingAIManager(
+    this.resetAIUseCase,
+    this.discoveryFeedManager,
+  ) : super(Loading());
+
+  late final _resetAIHandler = consume(resetAIUseCase, initialData: none);
+
+  void resetAI() => resetAIUseCase.call(none);
+
+  @override
+  Future<ResettingAIState?> computeState() async =>
+      fold(_resetAIHandler).foldAll(
+        (engineEvent, errorReport) {
+          final error = errorReport.of(_resetAIHandler);
+          if (error != null) {
+            return ResetFailed();
+          }
+
+          if (engineEvent is EngineExceptionRaised) {
+            return ResetFailed();
+          }
+
+          if (engineEvent.toString() == 'EngineEvent.resetAiSucceeded()') {
+            discoveryFeedManager.onResetAISucceeded();
+            return ResetSucceeded();
+          }
+          return state;
+        },
+      );
+}

--- a/application/lib/presentation/bottom_sheet/reset_ai/manager/resetting_ai_manager.dart
+++ b/application/lib/presentation/bottom_sheet/reset_ai/manager/resetting_ai_manager.dart
@@ -3,7 +3,6 @@ import 'package:injectable/injectable.dart';
 import 'package:xayn_architecture/xayn_architecture.dart';
 import 'package:xayn_discovery_app/infrastructure/discovery_engine/use_case/reset_ai_use_case.dart';
 import 'package:xayn_discovery_app/presentation/bottom_sheet/reset_ai/manager/resetting_ai_state.dart';
-import 'package:xayn_discovery_app/presentation/discovery_feed/manager/discovery_feed_manager.dart';
 import 'package:xayn_discovery_app/presentation/utils/overlay/overlay_manager_mixin.dart';
 
 @injectable
@@ -12,11 +11,9 @@ class ResettingAIManager extends Cubit<ResettingAIState>
         UseCaseBlocHelper<ResettingAIState>,
         OverlayManagerMixin<ResettingAIState> {
   final ResetAIUseCase resetAIUseCase;
-  final DiscoveryFeedManager discoveryFeedManager;
 
   ResettingAIManager(
     this.resetAIUseCase,
-    this.discoveryFeedManager,
   ) : super(Loading());
 
   late final UseCaseValueStream<bool> _resetAIHandler =
@@ -32,15 +29,14 @@ class ResettingAIManager extends Cubit<ResettingAIState>
           errorReport,
         ) {
           final error = errorReport.of(_resetAIHandler);
-          if (error != null) return ResetFailed();
-
-          if (resetAISucceeded == null) return state;
-
-          if (!resetAISucceeded) return ResetFailed();
-
-          if (resetAISucceeded) return ResetSucceeded();
-
-          return state;
+          final failed = error != null || resetAISucceeded == false;
+          if (failed) {
+            return ResetFailed();
+          } else if (resetAISucceeded == true) {
+            return ResetSucceeded();
+          } else {
+            return Loading();
+          }
         },
       );
 }

--- a/application/lib/presentation/bottom_sheet/reset_ai/manager/resetting_ai_manager.dart
+++ b/application/lib/presentation/bottom_sheet/reset_ai/manager/resetting_ai_manager.dart
@@ -5,7 +5,6 @@ import 'package:xayn_discovery_app/infrastructure/discovery_engine/use_case/rese
 import 'package:xayn_discovery_app/presentation/bottom_sheet/reset_ai/manager/resetting_ai_state.dart';
 import 'package:xayn_discovery_app/presentation/discovery_feed/manager/discovery_feed_manager.dart';
 import 'package:xayn_discovery_app/presentation/utils/overlay/overlay_manager_mixin.dart';
-import 'package:xayn_discovery_engine_flutter/discovery_engine.dart';
 
 @injectable
 class ResettingAIManager extends Cubit<ResettingAIState>
@@ -20,27 +19,27 @@ class ResettingAIManager extends Cubit<ResettingAIState>
     this.discoveryFeedManager,
   ) : super(Loading());
 
-  late final _resetAIHandler = consume(resetAIUseCase, initialData: none);
+  late final UseCaseValueStream<bool> _resetAIHandler =
+      consume(resetAIUseCase, initialData: none);
 
   void resetAI() => resetAIUseCase.call(none);
 
   @override
   Future<ResettingAIState?> computeState() async =>
       fold(_resetAIHandler).foldAll(
-        (engineEvent, errorReport) {
+        (
+          resetAISucceeded,
+          errorReport,
+        ) {
           final error = errorReport.of(_resetAIHandler);
-          if (error != null) {
-            return ResetFailed();
-          }
+          if (error != null) return ResetFailed();
 
-          if (engineEvent is EngineExceptionRaised) {
-            return ResetFailed();
-          }
+          if (resetAISucceeded == null) return state;
 
-          if (engineEvent.toString() == 'EngineEvent.resetAiSucceeded()') {
-            discoveryFeedManager.onResetAISucceeded();
-            return ResetSucceeded();
-          }
+          if (!resetAISucceeded) return ResetFailed();
+
+          if (resetAISucceeded) return ResetSucceeded();
+
           return state;
         },
       );

--- a/application/lib/presentation/bottom_sheet/reset_ai/manager/resetting_ai_state.dart
+++ b/application/lib/presentation/bottom_sheet/reset_ai/manager/resetting_ai_state.dart
@@ -1,0 +1,10 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'resetting_ai_state.freezed.dart';
+
+@freezed
+class ResettingAIState with _$ResettingAIState {
+  factory ResettingAIState.loading() = Loading;
+  factory ResettingAIState.resetSucceeded() = ResetSucceeded;
+  factory ResettingAIState.resetFailed() = ResetFailed;
+}

--- a/application/lib/presentation/bottom_sheet/reset_ai/widget/reset_ai_bottom_sheet.dart
+++ b/application/lib/presentation/bottom_sheet/reset_ai/widget/reset_ai_bottom_sheet.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+import 'package:xayn_discovery_app/presentation/bottom_sheet/model/bottom_sheet_footer/bottom_sheet_footer_button_data.dart';
+import 'package:xayn_discovery_app/presentation/bottom_sheet/model/bottom_sheet_footer/bottom_sheet_footer_data.dart';
+import 'package:xayn_discovery_app/presentation/bottom_sheet/widgets/bottom_sheet_footer.dart';
+import 'package:xayn_discovery_app/presentation/bottom_sheet/widgets/bottom_sheet_header.dart';
+import 'package:xayn_discovery_app/presentation/constants/r.dart';
+
+class ResetAIBottomSheet extends BottomSheetBase {
+  ResetAIBottomSheet({Key? key, VoidCallback? onSystemPop})
+      : super(
+          key: key,
+          body: _ResetAI(
+            onSystemPop: onSystemPop,
+          ),
+        );
+}
+
+class _ResetAI extends StatefulWidget {
+  const _ResetAI({
+    Key? key,
+    this.onSystemPop,
+  }) : super(
+          key: key,
+        );
+
+  final VoidCallback? onSystemPop;
+
+  @override
+  State<_ResetAI> createState() => __ResetAIState();
+}
+
+class __ResetAIState extends State<_ResetAI> with BottomSheetBodyMixin {
+  @override
+  Widget build(BuildContext context) {
+    final header = Padding(
+      padding: EdgeInsets.symmetric(vertical: R.dimen.unit),
+      child: BottomSheetHeader(
+        headerText: R.strings.bottomSheetResetAIHeader,
+      ),
+    );
+
+    final body = Text(R.strings.bottomSheetResetAIBody);
+
+    final footer = BottomSheetFooter(
+      onCancelPressed: () {
+        closeBottomSheet(context);
+        widget.onSystemPop?.call();
+      },
+      setup: _buildFooterSetup,
+    );
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        header,
+        body,
+        footer,
+      ],
+    );
+  }
+
+  BottomSheetFooterSetup get _buildFooterSetup => BottomSheetFooterSetup.column(
+        buttonsData: [
+          BottomSheetFooterButton(
+            text: R.strings.bottomSheetResetAIButton,
+            onPressed: () {
+              closeBottomSheet(context);
+            },
+          )
+        ],
+      );
+}

--- a/application/lib/presentation/bottom_sheet/reset_ai/widget/reset_ai_bottom_sheet.dart
+++ b/application/lib/presentation/bottom_sheet/reset_ai/widget/reset_ai_bottom_sheet.dart
@@ -7,11 +7,15 @@ import 'package:xayn_discovery_app/presentation/bottom_sheet/widgets/bottom_shee
 import 'package:xayn_discovery_app/presentation/constants/r.dart';
 
 class ResetAIBottomSheet extends BottomSheetBase {
-  ResetAIBottomSheet({Key? key, VoidCallback? onSystemPop})
-      : super(
+  ResetAIBottomSheet({
+    Key? key,
+    VoidCallback? onSystemPop,
+    required VoidCallback onResetAIPressed,
+  }) : super(
           key: key,
           body: _ResetAI(
             onSystemPop: onSystemPop,
+            onResetAIPressed: onResetAIPressed,
           ),
         );
 }
@@ -20,10 +24,12 @@ class _ResetAI extends StatefulWidget {
   const _ResetAI({
     Key? key,
     this.onSystemPop,
+    required this.onResetAIPressed,
   }) : super(
           key: key,
         );
 
+  final VoidCallback onResetAIPressed;
   final VoidCallback? onSystemPop;
 
   @override
@@ -66,6 +72,7 @@ class __ResetAIState extends State<_ResetAI> with BottomSheetBodyMixin {
           BottomSheetFooterButton(
             text: R.strings.bottomSheetResetAIButton,
             onPressed: () {
+              widget.onResetAIPressed();
               closeBottomSheet(context);
             },
           )

--- a/application/lib/presentation/bottom_sheet/reset_ai/widget/resetting_ai_bottom_sheet.dart
+++ b/application/lib/presentation/bottom_sheet/reset_ai/widget/resetting_ai_bottom_sheet.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:xayn_design/xayn_design.dart';
+import 'package:xayn_discovery_app/presentation/constants/r.dart';
+
+class ResettingAIBottomSheet extends BottomSheetBase {
+  ResettingAIBottomSheet({Key? key, VoidCallback? onSystemPop})
+      : super(
+          key: key,
+          body: _ResettingAI(
+            onSystemPop: onSystemPop,
+          ),
+        );
+}
+
+class _ResettingAI extends StatefulWidget {
+  const _ResettingAI({
+    Key? key,
+    this.onSystemPop,
+  }) : super(
+          key: key,
+        );
+
+  final VoidCallback? onSystemPop;
+
+  @override
+  State<_ResettingAI> createState() => __ResettingAIState();
+}
+
+class __ResettingAIState extends State<_ResettingAI> with BottomSheetBodyMixin {
+  @override
+  Widget build(BuildContext context) {
+    ///TODO
+    ///A timer used for closing the bottom sheet after few seconds
+    ///To remove when the business logic will be implemented
+    Future.delayed(const Duration(seconds: 3), () => closeBottomSheet(context));
+
+    final body = Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SizedBox(
+          height: R.dimen.unit3,
+        ),
+        CircularProgressIndicator(
+          color: R.colors.icon,
+        ),
+        SizedBox(
+          height: R.dimen.unit2,
+        ),
+        Text(R.strings.bottomSheetResettingAIBody),
+        SizedBox(
+          height: R.dimen.unit3,
+        ),
+      ],
+    );
+
+    return body;
+  }
+}

--- a/application/lib/presentation/bottom_sheet/widgets/bottom_sheet_footer.dart
+++ b/application/lib/presentation/bottom_sheet/widgets/bottom_sheet_footer.dart
@@ -61,21 +61,16 @@ class BottomSheetFooter extends StatelessWidget {
       Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          _buildRaisedButton(buttonsData[0]),
-          SizedBox(
-            height: R.dimen.unit0_5,
-          ),
-          _buildRaisedButton(buttonsData[1]),
-          SizedBox(
-            height: R.dimen.unit0_5,
-          ),
+          ...buttonsData.map(_buildRaisedButton),
           cancelButton,
         ],
       );
 
-  Widget _buildRaisedButton(BottomSheetFooterButton buttonData) =>
-      AppRaisedButton.text(
-        text: buttonData.text,
-        onPressed: buttonData.isDisabled ? null : buttonData.onPressed,
+  Widget _buildRaisedButton(BottomSheetFooterButton buttonData) => Padding(
+        padding: EdgeInsets.only(bottom: R.dimen.unit0_5),
+        child: AppRaisedButton.text(
+          text: buttonData.text,
+          onPressed: buttonData.isDisabled ? null : buttonData.onPressed,
+        ),
       );
 }

--- a/application/lib/presentation/constants/keys.dart
+++ b/application/lib/presentation/constants/keys.dart
@@ -38,6 +38,7 @@ class Keys {
       Key('settings_request_notification');
   static const Key settingsSendNotificationBtn =
       Key('settings_send_notification');
+  static const Key settingsResetAIOption = Key('settings_reset_ai_option');
 
   static const Key navBarItemBackBtn = Key('nav_bar_item_back_btn');
   static const Key navBarItemHome = Key('nav_bar_item_home');

--- a/application/lib/presentation/constants/translations/translations.i18n.yaml
+++ b/application/lib/presentation/constants/translations/translations.i18n.yaml
@@ -204,7 +204,7 @@ sourceExcludedTooltipMessage: Source hidden. Manage Sources
 manageSourcesTooltipMessage: Manage Sources
 allowSourceBackMenuItemTitle: Allow this source back on my feed
 sourceAllowedBackTooltipMessage: Source allowed back
-bottomSheetResetAIBody: This clears your personalisation history of read, liked and disliked articles. It won't affect your source preferences, country settings or collections.
+bottomSheetResetAIBody: This clears your personalisation history. It won't affect your source preferences, country settings or collections.
 bottomSheetResetAIHeader: Are you sure?
 bottomSheetResetAIButton: Reset now
 feedSettingsScreenResetAIOption: Reset AI

--- a/application/lib/presentation/constants/translations/translations_de.i18n.yaml
+++ b/application/lib/presentation/constants/translations/translations_de.i18n.yaml
@@ -193,13 +193,13 @@ noExcludedSourcesYet: Noch keine verborgenen Quellen
 noSourcesFoundTitle: Keine Ergebnisse
 noSourcesFoundInfo: Wir konnten keine Quellen für diese Suche finden
 sourceExcludedTooltipMessage: Quelle verborgen. Quellen verwalten
-manageSourcesTooltipMessage: Manage Sources
-allowSourceBackMenuItemTitle: Allow this source back on my feed
+manageSourcesTooltipMessage: Quellen verwalten
+allowSourceBackMenuItemTitle: Diese Quelle wieder im Feed zulassen
 sourceAllowedBackTooltipMessage: Quelle wieder erlaubt
-bottomSheetResetAIBody: This clears your personalisation history of read, liked and disliked articles. It won't affect your source preferences, country settings or collections.
-bottomSheetResetAIHeader: Are you sure?
-bottomSheetResetAIButton: Reset now
-feedSettingsScreenResetAIOption: Reset AI
-bottomSheetResettingAIBody: Resetting...
-notificationsChannelName: Basic notifications
-notificationsChannelDescription: Notification channel for basic tests
+bottomSheetResetAIBody: Dadurch wird Dein Personalisierungsverlauf gelöscht. Dies wirkt sich nicht auf Deine Quelleneinstellungen, Ländereinstellungen oder Sammlungen aus.
+bottomSheetResetAIHeader: Bist du dir sicher?
+bottomSheetResetAIButton: Zurücksetzen
+feedSettingsScreenResetAIOption: KI zurücksetzen
+bottomSheetResettingAIBody: Zurücksetzen...
+notificationsChannelName: Benachrichtigungen
+notificationsChannelDescription: Benachrichtigungskanal für Tests

--- a/application/lib/presentation/constants/translations/translations_es.i18n.yaml
+++ b/application/lib/presentation/constants/translations/translations_es.i18n.yaml
@@ -196,10 +196,10 @@ sourceExcludedTooltipMessage: Fuente oculta. Administrar fuentes
 manageSourcesTooltipMessage: Fuentes administradas
 allowSourceBackMenuItemTitle: Permitir esta fuente nuevamente en mi feed
 sourceAllowedBackTooltipMessage: Fuente permitida nuevamente
-bottomSheetResetAIBody: This clears your personalisation history of read, liked and disliked articles. It won't affect your source preferences, country settings or collections.
-bottomSheetResetAIHeader: Are you sure?
-bottomSheetResetAIButton: Reset now
-feedSettingsScreenResetAIOption: Reset AI
-bottomSheetResettingAIBody: Resetting...
-notificationsChannelName: Basic notifications
-notificationsChannelDescription: Notification channel for basic tests
+bottomSheetResetAIBody: Esto borra su historial de personalización. No afectará sus preferencias de fuente, configuración de país o colecciones.
+bottomSheetResetAIHeader: Estas segura?
+bottomSheetResetAIButton: Restablecer
+feedSettingsScreenResetAIOption: Restablecer IA
+bottomSheetResettingAIBody: Restableciendo...
+notificationsChannelName: Notificaciones básicas
+notificationsChannelDescription: Canal de notificaciones para pruebas

--- a/application/lib/presentation/constants/translations/translations_fr.i18n.yaml
+++ b/application/lib/presentation/constants/translations/translations_fr.i18n.yaml
@@ -193,13 +193,13 @@ noExcludedSourcesYet: Pas encore de sources cachées
 noSourcesFoundTitle: Aucun résultat
 noSourcesFoundInfo: Nous n'avons trouvé aucune source pour votre recherche
 sourceExcludedTooltipMessage: Source caché. Gérer les sources
-manageSourcesTooltipMessage: Manage Sources
-allowSourceBackMenuItemTitle: Allow this source back on my feed
-sourceAllowedBackTooltipMessage: Quelle erlaubt zurück
-bottomSheetResetAIBody: This clears your personalisation history of read, liked and disliked articles. It won't affect your source preferences, country settings or collections.
-bottomSheetResetAIHeader: Are you sure?
-bottomSheetResetAIButton: Reset now
-feedSettingsScreenResetAIOption: Reset AI
-bottomSheetResettingAIBody: Resetting...
-notificationsChannelName: Basic notifications
-notificationsChannelDescription: Notification channel for basic tests
+manageSourcesTooltipMessage: Gérer les sources
+allowSourceBackMenuItemTitle: Autoriser cette source à revenir sur mon flux
+sourceAllowedBackTooltipMessage: Source autorisée
+bottomSheetResetAIBody: Cela efface votre historique de personnalisation. Cela n'affectera pas vos préférences de source, vos paramètres de pays ou vos collections.
+bottomSheetResetAIHeader: Êtes-vous sûr?
+bottomSheetResetAIButton: Réinitialiser
+feedSettingsScreenResetAIOption: Réinitialiser l'IA
+bottomSheetResettingAIBody: Réinitialisation...
+notificationsChannelName: Notifications basiques
+notificationsChannelDescription: Canal de notification pour les tests

--- a/application/lib/presentation/constants/translations/translations_nl.i18n.yaml
+++ b/application/lib/presentation/constants/translations/translations_nl.i18n.yaml
@@ -193,13 +193,13 @@ noExcludedSourcesYet: Nog geen verborgen bronnen
 noSourcesFoundTitle: Geen resultaten
 noSourcesFoundInfo: We konden geen bronnen vinden voor je zoekopdracht
 sourceExcludedTooltipMessage: Bron verborgen. Bronnen beheren
-manageSourcesTooltipMessage: Manage Sources
-allowSourceBackMenuItemTitle: Allow this source back on my feed
-sourceAllowedBackTooltipMessage: Source allowed back
-bottomSheetResetAIBody: This clears your personalisation history of read, liked and disliked articles. It won't affect your source preferences, country settings or collections.
-bottomSheetResetAIHeader: Are you sure?
-bottomSheetResetAIButton: Reset now
-feedSettingsScreenResetAIOption: Reset AI
-bottomSheetResettingAIBody: Resetting...
-notificationsChannelName: Basic notifications
-notificationsChannelDescription: Notification channel for basic tests
+manageSourcesTooltipMessage: Bronnen beheren
+allowSourceBackMenuItemTitle: Sta deze bron weer toe op mijn feed
+sourceAllowedBackTooltipMessage: Bron toegestaan terug
+bottomSheetResetAIBody: Hiermee wordt uw personalisatiegeschiedenis. Het heeft geen invloed op je bronvoorkeuren, landinstellingen of collecties.
+bottomSheetResetAIHeader: Weet je het zeker?
+bottomSheetResetAIButton: Nu resetten
+feedSettingsScreenResetAIOption: AI resetten
+bottomSheetResettingAIBody: Resetten...
+notificationsChannelName: Basismeldingen
+notificationsChannelDescription: Meldingskanaal voor testen

--- a/application/lib/presentation/constants/translations/translations_pl.i18n.yaml
+++ b/application/lib/presentation/constants/translations/translations_pl.i18n.yaml
@@ -196,7 +196,7 @@ sourceExcludedTooltipMessage: Source hidden. Manage Sources
 manageSourcesTooltipMessage: Manage Sources
 allowSourceBackMenuItemTitle: Allow this source back on my feed
 sourceAllowedBackTooltipMessage: Source allowed back
-bottomSheetResetAIBody: This clears your personalisation history of read, liked and disliked articles. It won't affect your source preferences, country settings or collections.
+bottomSheetResetAIBody: This clears your personalisation history. It won't affect your source preferences, country settings or collections.
 bottomSheetResetAIHeader: Are you sure?
 bottomSheetResetAIButton: Reset now
 feedSettingsScreenResetAIOption: Reset AI

--- a/application/lib/presentation/discovery_feed/manager/discovery_feed_manager.dart
+++ b/application/lib/presentation/discovery_feed/manager/discovery_feed_manager.dart
@@ -295,7 +295,7 @@ class DiscoveryFeedManager extends BaseDiscoveryManager
               lastResults = nextFeedBatchRequestFailed(event);
             } else if (event is RestoreFeedFailed) {
               lastResults = restoreFeedFailed(event);
-            } else if (event.toString() == 'EngineEvent.resetAiSucceeded()') {
+            } else if (event is ResetAiSucceeded) {
               lastResults = {};
             } else {
               lastResults = orElse();

--- a/application/lib/presentation/discovery_feed/manager/discovery_feed_manager.dart
+++ b/application/lib/presentation/discovery_feed/manager/discovery_feed_manager.dart
@@ -43,6 +43,8 @@ const int _kMaxCardCount = 10;
 typedef OnRestoreFeedSucceeded = Set<Document> Function(
     RestoreFeedSucceeded event);
 typedef OnRestoreFeedFailed = Set<Document> Function(RestoreFeedFailed event);
+
+typedef OnResetAiSucceeded = Set<Document> Function(ResetAiSucceeded event);
 typedef OnNextFeedBatchRequestSucceeded = Set<Document> Function(
     NextFeedBatchRequestSucceeded event);
 typedef OnNextFeedBatchRequestFailed = Set<Document> Function(
@@ -274,6 +276,7 @@ class DiscoveryFeedManager extends BaseDiscoveryManager
         required OnEngineExceptionRaised engineExceptionRaised,
         required OnNextFeedBatchRequestFailed nextFeedBatchRequestFailed,
         required OnRestoreFeedFailed restoreFeedFailed,
+        required OnResetAiSucceeded resetAiSucceeded,
         required OnNonMatchedEngineEvent orElse,
       }) =>
           (EngineEvent? event) {
@@ -296,6 +299,7 @@ class DiscoveryFeedManager extends BaseDiscoveryManager
             } else if (event is RestoreFeedFailed) {
               lastResults = restoreFeedFailed(event);
             } else if (event is ResetAiSucceeded) {
+              self.onResetAISucceeded();
               lastResults = {};
             } else {
               lastResults = orElse();
@@ -350,6 +354,10 @@ class DiscoveryFeedManager extends BaseDiscoveryManager
 
           return lastResults;
         },
+
+        ///TODO will add the analytics
+        resetAiSucceeded: (event) => lastResults,
+
         orElse: () => lastResults,
       );
     };

--- a/application/lib/presentation/discovery_feed/manager/discovery_feed_manager.dart
+++ b/application/lib/presentation/discovery_feed/manager/discovery_feed_manager.dart
@@ -238,6 +238,12 @@ class DiscoveryFeedManager extends BaseDiscoveryManager
     resetObservedDocument();
   }
 
+  void onResetAISucceeded() {
+    resetParameters();
+    requestNextFeedBatch();
+    handleIndexChanged(0);
+  }
+
   /// A higher-order Function, which tracks the last event passed in,
   /// and ultimately runs the inner fold Function when the incoming event
   /// no longer matches lastEvent.
@@ -289,6 +295,8 @@ class DiscoveryFeedManager extends BaseDiscoveryManager
               lastResults = nextFeedBatchRequestFailed(event);
             } else if (event is RestoreFeedFailed) {
               lastResults = restoreFeedFailed(event);
+            } else if (event.toString() == 'EngineEvent.resetAiSucceeded()') {
+              lastResults = {};
             } else {
               lastResults = orElse();
             }

--- a/application/lib/presentation/feature/manager/feature_manager.dart
+++ b/application/lib/presentation/feature/manager/feature_manager.dart
@@ -41,6 +41,8 @@ class FeatureManager extends Cubit<FeatureManagerState>
   bool get arePushNotificationDeepLinksEnabled =>
       isEnabled(Feature.pushNotificationDeepLinks);
 
+  bool get isResetAIEnabled => isEnabled(Feature.resetAI);
+
   bool get showDiscoveryEngineReportOverlay =>
       isEnabled(Feature.discoveryEngineReportOverlay);
 

--- a/application/lib/presentation/settings/manager/settings_manager.dart
+++ b/application/lib/presentation/settings/manager/settings_manager.dart
@@ -216,7 +216,11 @@ class SettingsScreenManager extends Cubit<SettingsScreenState>
   void onResetAIPressed() => showOverlay(
         OverlayData.bottomSheetResetAI(
           onResetAIPressed: () => showOverlay(
-            OverlayData.bottomSheetResettingAI(),
+            OverlayData.bottomSheetResettingAI(
+              onResetAIFailed: () => showOverlay(
+                OverlayData.bottomSheetGenericError(),
+              ),
+            ),
           ),
         ),
       );

--- a/application/lib/presentation/settings/manager/settings_manager.dart
+++ b/application/lib/presentation/settings/manager/settings_manager.dart
@@ -214,7 +214,11 @@ class SettingsScreenManager extends Cubit<SettingsScreenState>
       _settingsNavActions.onSourcesOptionsPressed();
 
   void onResetAIPressed() => showOverlay(
-        OverlayData.bottomSheetResetAI(),
+        OverlayData.bottomSheetResetAI(
+          onResetAIPressed: () => showOverlay(
+            OverlayData.bottomSheetResettingAI(),
+          ),
+        ),
       );
 
   void onSubscriptionSectionPressed({

--- a/application/lib/presentation/settings/manager/settings_manager.dart
+++ b/application/lib/presentation/settings/manager/settings_manager.dart
@@ -213,6 +213,10 @@ class SettingsScreenManager extends Cubit<SettingsScreenState>
   void onSourcesOptionsPressed() =>
       _settingsNavActions.onSourcesOptionsPressed();
 
+  void onResetAIPressed() => showOverlay(
+        OverlayData.bottomSheetResetAI(),
+      );
+
   void onSubscriptionSectionPressed({
     required SubscriptionStatus subscriptionStatus,
   }) {

--- a/application/lib/presentation/settings/settings_screen.dart
+++ b/application/lib/presentation/settings/settings_screen.dart
@@ -128,6 +128,7 @@ class _SettingsScreenState extends State<SettingsScreen>
         isFirstSection: !isPaymentEnabled,
         onCountriesPressed: _manager.onCountriesOptionsPressed,
         onSourcesPressed: _manager.onSourcesOptionsPressed,
+        onResetAIPressed: _manager.onResetAIPressed,
       );
 
   Widget _buildAppThemeSection({

--- a/application/lib/presentation/settings/widget/home_feed_settings_section.dart
+++ b/application/lib/presentation/settings/widget/home_feed_settings_section.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:xayn_design/xayn_design.dart';
+import 'package:xayn_discovery_app/infrastructure/di/di_config.dart';
 import 'package:xayn_discovery_app/presentation/constants/keys.dart';
 import 'package:xayn_discovery_app/presentation/constants/r.dart';
+import 'package:xayn_discovery_app/presentation/feature/manager/feature_manager.dart';
 
 class SettingsHomeFeedSection extends StatelessWidget {
   final VoidCallback onSourcesPressed;
@@ -9,13 +11,15 @@ class SettingsHomeFeedSection extends StatelessWidget {
   final VoidCallback onResetAIPressed;
   final bool isFirstSection;
 
-  const SettingsHomeFeedSection({
+  SettingsHomeFeedSection({
     Key? key,
     required this.onSourcesPressed,
     required this.onCountriesPressed,
     required this.onResetAIPressed,
     this.isFirstSection = false,
   }) : super(key: key);
+
+  late final FeatureManager _featureManager = di.get();
 
   @override
   Widget build(BuildContext context) => SettingsSection(
@@ -24,7 +28,7 @@ class SettingsHomeFeedSection extends StatelessWidget {
         items: [
           _buildSourcesOption(),
           _buildCountriesOption(),
-          _buildResetAIOption(),
+          if (_featureManager.isResetAIEnabled) _buildResetAIOption(),
         ],
       );
 

--- a/application/lib/presentation/settings/widget/home_feed_settings_section.dart
+++ b/application/lib/presentation/settings/widget/home_feed_settings_section.dart
@@ -6,12 +6,14 @@ import 'package:xayn_discovery_app/presentation/constants/r.dart';
 class SettingsHomeFeedSection extends StatelessWidget {
   final VoidCallback onSourcesPressed;
   final VoidCallback onCountriesPressed;
+  final VoidCallback onResetAIPressed;
   final bool isFirstSection;
 
   const SettingsHomeFeedSection({
     Key? key,
     required this.onSourcesPressed,
     required this.onCountriesPressed,
+    required this.onResetAIPressed,
     this.isFirstSection = false,
   }) : super(key: key);
 
@@ -22,6 +24,7 @@ class SettingsHomeFeedSection extends StatelessWidget {
         items: [
           _buildSourcesOption(),
           _buildCountriesOption(),
+          _buildResetAIOption(),
         ],
       );
 
@@ -45,6 +48,18 @@ class SettingsHomeFeedSection extends StatelessWidget {
             key: Keys.settingsCountriesOption,
             svgIconPath: R.assets.icons.arrowRight,
             onPressed: onCountriesPressed,
+          ),
+        ),
+      );
+
+  SettingsCardData _buildResetAIOption() => SettingsCardData.fromTile(
+        SettingsTileData(
+          title: R.strings.feedSettingsScreenResetAIOption,
+          svgIconPath: R.assets.icons.brainy,
+          action: SettingsTileActionIcon(
+            key: Keys.settingsResetAIOption,
+            svgIconPath: R.assets.icons.arrowRight,
+            onPressed: onResetAIPressed,
           ),
         ),
       );

--- a/application/lib/presentation/utils/overlay/overlay_data.dart
+++ b/application/lib/presentation/utils/overlay/overlay_data.dart
@@ -29,6 +29,7 @@ import 'package:xayn_discovery_app/presentation/bottom_sheet/onboarding/widget/o
 import 'package:xayn_discovery_app/presentation/bottom_sheet/promo_code/promo_code_applied_bottom_sheet.dart';
 import 'package:xayn_discovery_app/presentation/bottom_sheet/promo_code/redeem_promo_code_bottom_sheet.dart';
 import 'package:xayn_discovery_app/presentation/bottom_sheet/reset_ai/widget/reset_ai_bottom_sheet.dart';
+import 'package:xayn_discovery_app/presentation/bottom_sheet/reset_ai/widget/resetting_ai_bottom_sheet.dart';
 import 'package:xayn_discovery_app/presentation/constants/r.dart';
 import 'package:xayn_discovery_app/presentation/payment/payment_bottom_sheet.dart';
 import 'package:xayn_discovery_app/presentation/premium/widgets/subscription_details_bottom_sheet.dart';
@@ -348,10 +349,22 @@ class OverlayData {
       );
 
   static BottomSheetData bottomSheetResetAI({
+    required VoidCallback onResetAIPressed,
     VoidCallback? onSystemPop,
   }) =>
       BottomSheetData(
         builder: (_, __) => ResetAIBottomSheet(
+          onSystemPop: onSystemPop,
+          onResetAIPressed: onResetAIPressed,
+        ),
+      );
+  static BottomSheetData bottomSheetResettingAI({
+    VoidCallback? onSystemPop,
+    bool isDismissible = false,
+  }) =>
+      BottomSheetData(
+        isDismissible: isDismissible,
+        builder: (_, __) => ResettingAIBottomSheet(
           onSystemPop: onSystemPop,
         ),
       );

--- a/application/lib/presentation/utils/overlay/overlay_data.dart
+++ b/application/lib/presentation/utils/overlay/overlay_data.dart
@@ -28,6 +28,7 @@ import 'package:xayn_discovery_app/presentation/bottom_sheet/move_to_collection/
 import 'package:xayn_discovery_app/presentation/bottom_sheet/onboarding/widget/onboarding_bottom_sheet.dart';
 import 'package:xayn_discovery_app/presentation/bottom_sheet/promo_code/promo_code_applied_bottom_sheet.dart';
 import 'package:xayn_discovery_app/presentation/bottom_sheet/promo_code/redeem_promo_code_bottom_sheet.dart';
+import 'package:xayn_discovery_app/presentation/bottom_sheet/reset_ai/widget/reset_ai_bottom_sheet.dart';
 import 'package:xayn_discovery_app/presentation/constants/r.dart';
 import 'package:xayn_discovery_app/presentation/payment/payment_bottom_sheet.dart';
 import 'package:xayn_discovery_app/presentation/premium/widgets/subscription_details_bottom_sheet.dart';
@@ -344,6 +345,15 @@ class OverlayData {
       BottomSheetData(
         allowStacking: allowStacking,
         builder: (_, __) => NoActiveSubscriptionFoundErrorBottomSheet(),
+      );
+
+  static BottomSheetData bottomSheetResetAI({
+    VoidCallback? onSystemPop,
+  }) =>
+      BottomSheetData(
+        builder: (_, __) => ResetAIBottomSheet(
+          onSystemPop: onSystemPop,
+        ),
       );
 }
 

--- a/application/lib/presentation/utils/overlay/overlay_data.dart
+++ b/application/lib/presentation/utils/overlay/overlay_data.dart
@@ -361,11 +361,13 @@ class OverlayData {
   static BottomSheetData bottomSheetResettingAI({
     VoidCallback? onSystemPop,
     bool isDismissible = false,
+    required VoidCallback onResetAIFailed,
   }) =>
       BottomSheetData(
         isDismissible: isDismissible,
         builder: (_, __) => ResettingAIBottomSheet(
           onSystemPop: onSystemPop,
+          onResetAIFailed: onResetAIFailed,
         ),
       );
 }

--- a/application/lib/presentation/widget/shimmering_feed_view.dart
+++ b/application/lib/presentation/widget/shimmering_feed_view.dart
@@ -34,6 +34,13 @@ class ShimmeringFeedView extends StatelessWidget {
     resource: _resource,
     batchIndex: -1,
     userReaction: UserReaction.neutral,
+
+    /// StackId.nil() is supposed to be used only for testing but in this case we
+    /// might use it because the document that we're creating is used for the
+    /// shimmering view
+    ///
+    // ignore: invalid_use_of_visible_for_testing_member
+    stackId: StackId.nil(),
   );
 
   ShimmeringFeedView({

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -100,7 +100,7 @@ dependencies:
   xayn_discovery_engine_flutter:
     git:
       url: https://gitlab.com/xayn/xayn_discovery_engine_release
-      ref: c31313e6577badabf291a8cc08bc2d63c09ce07f
+      ref: 328abe7726a1e8acb9f8392a28d526ffb1e1c5eb
       path: discovery_engine_flutter
   xayn_readability:
     git:
@@ -120,7 +120,7 @@ dependency_overrides:
 # Please list dependencies alphabetically!
 dev_dependencies:
   bloc_test: 8.5.0
-  build_runner: 2.1.8
+  build_runner: 2.1.11
   envify_generator: 2.0.2
   flutter_lints: 2.0.1
   flutter_test:

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -96,7 +96,7 @@ dependencies:
   xayn_design:
     git:
       url: git@github.com:xaynetwork/xayn_design.git
-      ref: 34cffbf9bc799b95a6a9eb52e509850d4ce93075
+      ref: a20fd18491d6799e8ec4394646c8f8dad1becc60
   xayn_discovery_engine_flutter:
     git:
       url: https://gitlab.com/xayn/xayn_discovery_engine_release

--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -96,7 +96,7 @@ dependencies:
   xayn_design:
     git:
       url: git@github.com:xaynetwork/xayn_design.git
-      ref: 1d700cb37c2c7e16b57a422a52cf00aa683630ee
+      ref: 34cffbf9bc799b95a6a9eb52e509850d4ce93075
   xayn_discovery_engine_flutter:
     git:
       url: https://gitlab.com/xayn/xayn_discovery_engine_release

--- a/application/test/presentation/bottom_sheet/move_to_collection/manager/move_to_collection_manager_test.dart
+++ b/application/test/presentation/bottom_sheet/move_to_collection/manager/move_to_collection_manager_test.dart
@@ -60,6 +60,7 @@ void main() {
           ),
           batchIndex: -1,
           userReaction: UserReaction.positive,
+          stackId: StackId.nil(),
         );
 
     final documentMarkedPositive = createDocumentMarkedPositive();

--- a/application/test/presentation/discovery_engine/mixin/observe_document_mixin_test.dart
+++ b/application/test/presentation/discovery_engine/mixin/observe_document_mixin_test.dart
@@ -35,6 +35,7 @@ void main() {
       score: .0,
       topic: 'topic',
     ),
+    stackId: StackId.nil(),
   );
 
   setUp(() async {

--- a/application/test/presentation/discovery_feed/discovery_feed_manager_test.dart
+++ b/application/test/presentation/discovery_feed/discovery_feed_manager_test.dart
@@ -51,23 +51,24 @@ void main() async {
   final subscriptionStatusInitial = SubscriptionStatus.initial();
 
   createFakeDocument() => Document(
-      documentId: DocumentId(),
-      resource: NewsResource(
-        image: Uri.parse('https://displayUrl.test.xayn.com'),
-        sourceDomain: Source('example'),
-        topic: 'topic',
-        score: .0,
-        rank: -1,
-        language: 'en-US',
-        country: 'US',
-        snippet: 'snippet',
-        title: 'title',
-        url: Uri.parse('https://url.test.xayn.com'),
-        datePublished: DateTime.parse("2021-01-01 00:00:00.000Z"),
-      ),
-      batchIndex: -1,
-      userReaction: UserReaction.neutral,
-      stackId: StackId.nil());
+        documentId: DocumentId(),
+        resource: NewsResource(
+          image: Uri.parse('https://displayUrl.test.xayn.com'),
+          sourceDomain: Source('example'),
+          topic: 'topic',
+          score: .0,
+          rank: -1,
+          language: 'en-US',
+          country: 'US',
+          snippet: 'snippet',
+          title: 'title',
+          url: Uri.parse('https://url.test.xayn.com'),
+          datePublished: DateTime.parse("2021-01-01 00:00:00.000Z"),
+        ),
+        batchIndex: -1,
+        userReaction: UserReaction.neutral,
+        stackId: StackId.nil(),
+      );
 
   final fakeDocumentA = createFakeDocument();
   final fakeDocumentB = createFakeDocument();

--- a/application/test/presentation/discovery_feed/discovery_feed_manager_test.dart
+++ b/application/test/presentation/discovery_feed/discovery_feed_manager_test.dart
@@ -51,23 +51,23 @@ void main() async {
   final subscriptionStatusInitial = SubscriptionStatus.initial();
 
   createFakeDocument() => Document(
-        documentId: DocumentId(),
-        resource: NewsResource(
-          image: Uri.parse('https://displayUrl.test.xayn.com'),
-          sourceDomain: Source('example'),
-          topic: 'topic',
-          score: .0,
-          rank: -1,
-          language: 'en-US',
-          country: 'US',
-          snippet: 'snippet',
-          title: 'title',
-          url: Uri.parse('https://url.test.xayn.com'),
-          datePublished: DateTime.parse("2021-01-01 00:00:00.000Z"),
-        ),
-        batchIndex: -1,
-        userReaction: UserReaction.neutral,
-      );
+      documentId: DocumentId(),
+      resource: NewsResource(
+        image: Uri.parse('https://displayUrl.test.xayn.com'),
+        sourceDomain: Source('example'),
+        topic: 'topic',
+        score: .0,
+        rank: -1,
+        language: 'en-US',
+        country: 'US',
+        snippet: 'snippet',
+        title: 'title',
+        url: Uri.parse('https://url.test.xayn.com'),
+        datePublished: DateTime.parse("2021-01-01 00:00:00.000Z"),
+      ),
+      batchIndex: -1,
+      userReaction: UserReaction.neutral,
+      stackId: StackId.nil());
 
   final fakeDocumentA = createFakeDocument();
   final fakeDocumentB = createFakeDocument();

--- a/application/test/presentation/feature/widget/select_feature_screen_test.dart
+++ b/application/test/presentation/feature/widget/select_feature_screen_test.dart
@@ -26,6 +26,7 @@ void main() {
       when(manager.showDiscoveryEngineReportOverlay).thenReturn(false);
       when(manager.isTtsEnabled).thenReturn(false);
       when(manager.isNewExcludeSourceFlowEnabled).thenReturn(false);
+      when(manager.isResetAIEnabled).thenReturn(false);
 
       // we swap FeatureScreen with another one
       await tester.initToDiscoveryPage();

--- a/application/test/test_utils/fakes.dart
+++ b/application/test/test_utils/fakes.dart
@@ -30,6 +30,7 @@ final fakeDocument = Document(
     datePublished: DateTime.parse("2021-12-29 07:59:49.000Z"),
   ),
   batchIndex: -1,
+  stackId: StackId.nil(),
 );
 
 AppImageCacheManager createFakeImageCacheManager() {


### PR DESCRIPTION
### What 🕵️ 🔍

- What exactly was added or modified?
Adds the reset AI option in the settings screen
Creates the reset AI bottom sheet
Creates the resetting AI bottom sheet (shown when the resetting is in progress)
Adds feature flag 

----------

### How to test (please adjust template) 🥼 🔬
- Feature flag enabled:
  Test main feature, and verify that all aspects of the story are working as described in the PR and the Jira story
  - [x] Go to the settings screen and tap on the reset AI option
  - [x] Check that a bottom sheet asking you for confirmation is shown
  - [x] When tapping on confirmation button another bottom sheet is shown, displaying that the resetting is in progress (currently there is no business logic for resetting the AI, therefore there is a timer of 3 seconds after that the bottom sheet automatically closes). 
  - [x] While opened, check that the bottom sheet showing the resetting of the AI in progress is not dismissible (clicking outside should not close it)
  - [x] Check that all the strings correspond to the one shown in Figma

- Feature flag disabled:
  - [x] Check that the reset AI option doesn't appear in the settings screen

----------

### Screenshots 📸 📱

| Demo |
<video width="280" src="https://user-images.githubusercontent.com/74236996/177733524-f6be8fb8-06a1-441f-836b-8f479ed2f19b.mov"> |




----------

### References 📝 🔗

- [JIRA](https://xainag.atlassian.net/browse/TB-4025)
- [FIGMA](https://www.figma.com/file/hGAst3K9ZQIHmQoCNjbgaZ/Discovery-App-%7C-Design?node-id=391%3A1139)
----------