### PR TITLE
TB-4028 Add analytics events for the reset of the AI

### DIFF
--- a/application/lib/infrastructure/service/analytics/events/open_reset_ai_window_event.dart
+++ b/application/lib/infrastructure/service/analytics/events/open_reset_ai_window_event.dart
@@ -1,0 +1,10 @@
+import 'package:xayn_discovery_app/domain/model/analytics/analytics_event.dart';
+
+const String _kEventType = 'resetAIWindow';
+
+class OpenResetAIWindowEvent extends AnalyticsEvent {
+  OpenResetAIWindowEvent()
+      : super(
+          _kEventType,
+        );
+}

--- a/application/lib/infrastructure/service/analytics/events/reset_ai_action_event.dart
+++ b/application/lib/infrastructure/service/analytics/events/reset_ai_action_event.dart
@@ -1,0 +1,20 @@
+import 'package:xayn_discovery_app/domain/model/analytics/analytics_event.dart';
+
+const String _kEventType = 'resetAIAction';
+const String _kParamAction = 'action';
+
+enum ResetAIActionValueEnum {
+  reset,
+  cancel,
+}
+
+class ResetAIActionEvent extends AnalyticsEvent {
+  ResetAIActionEvent({
+    required ResetAIActionValueEnum action,
+  }) : super(
+          _kEventType,
+          properties: {
+            _kParamAction: action.name,
+          },
+        );
+}

--- a/application/lib/presentation/settings/manager/settings_manager.dart
+++ b/application/lib/presentation/settings/manager/settings_manager.dart
@@ -12,6 +12,8 @@ import 'package:xayn_discovery_app/infrastructure/service/analytics/events/bug_r
 import 'package:xayn_discovery_app/infrastructure/service/analytics/events/feedback_given_event.dart';
 import 'package:xayn_discovery_app/infrastructure/service/analytics/events/open_external_url_event.dart';
 import 'package:xayn_discovery_app/infrastructure/service/analytics/events/open_subscription_window_event.dart';
+import 'package:xayn_discovery_app/infrastructure/service/analytics/events/open_reset_ai_window_event.dart';
+import 'package:xayn_discovery_app/infrastructure/service/analytics/events/reset_ai_action_event.dart';
 import 'package:xayn_discovery_app/infrastructure/service/analytics/events/subscription_action_event.dart';
 import 'package:xayn_discovery_app/infrastructure/service/bug_reporting/bug_reporting_service.dart';
 import 'package:xayn_discovery_app/infrastructure/service/notifications/local_notifications_service.dart';
@@ -213,17 +215,31 @@ class SettingsScreenManager extends Cubit<SettingsScreenState>
   void onSourcesOptionsPressed() =>
       _settingsNavActions.onSourcesOptionsPressed();
 
-  void onResetAIPressed() => showOverlay(
-        OverlayData.bottomSheetResetAI(
-          onResetAIPressed: () => showOverlay(
+  void onResetAIPressed() {
+    _sendAnalyticsUseCase(OpenResetAIWindowEvent());
+
+    showOverlay(
+      OverlayData.bottomSheetResetAI(
+        onSystemPop: () => _sendAnalyticsUseCase(
+          ResetAIActionEvent(
+            action: ResetAIActionValueEnum.cancel,
+          ),
+        ),
+        onResetAIPressed: () {
+          _sendAnalyticsUseCase(
+            ResetAIActionEvent(action: ResetAIActionValueEnum.reset),
+          );
+          showOverlay(
             OverlayData.bottomSheetResettingAI(
               onResetAIFailed: () => showOverlay(
                 OverlayData.bottomSheetGenericError(),
               ),
             ),
-          ),
-        ),
-      );
+          );
+        },
+      ),
+    );
+  }
 
   void onSubscriptionSectionPressed({
     required SubscriptionStatus subscriptionStatus,


### PR DESCRIPTION
### What 🕵️ 🔍

- What does the pull request solve?
Adds analytics event for the reset of the AI

----------

### How to test (please adjust template) 🥼 🔬
- Feature flag enabled:
  Test main feature, and verify that all aspects of the story are working as described in the PR and the Jira story
  - [ ] Tap on the `Reset AI` option in the settings screen and verify that the event is fired
  - [ ] Tap on the `Reset AI`button of the bottom sheet and verify that the event with action set to `reset`is fired
  - [ ] Tap on the `Cancel`button of the bottom sheet and verify that the event with action set to `cancel`is fired

----------

### Screenshots 📸 📱

| Before | After  |
| ------ | ------ |
| <img width="280" src=""> | <img width="280" src=""> |

----------

### References 📝 🔗

- [JIRA](https://xainag.atlassian.net/browse/TB-4028)

----------