### PR TITLE
Do not open gibberish documents

### DIFF
--- a/application/lib/presentation/discovery_card/widget/check_valid_document_mixin.dart
+++ b/application/lib/presentation/discovery_card/widget/check_valid_document_mixin.dart
@@ -30,12 +30,8 @@ mixin CheckValidDocumentMixin<T> on OverlayManagerMixin<T> {
     if (processedDocument != null) {
       final html = processedDocument.processHtmlResult.contents ?? '';
       final isInvalidHtml = html.trim().isEmpty;
-      // TODO after some intensive testing period we should enable gibberish detection to block content,
-      // but for now it is better to use the red globe as an indicator
-      // final isGibberish = (_featureManager.isGibberishEnabled &&
-      //     !discoveryCardManager.state.textIsReadable);
-      // if (isInvalidHtml || isGibberish) {
-      if (isInvalidHtml) {
+      final isGibberish = !discoveryCardManager.state.textIsReadable;
+      if (isInvalidHtml || isGibberish) {
         showOverlay(
           OverlayData.bottomSheetReaderModeUnavailableBottomSheet(
             isDismissible: isDismissible,


### PR DESCRIPTION
### What 🕵️ 🔍

- When detecting gibberish do not open a document but show the bottomsheet to jump to the website
- just one check in application/lib/presentation/discovery_card/widget/check_valid_document_mixin.dart

----------

### How to test (please adjust template) 🥼 🔬

  - [ ] Connect the device to the computer to read the logs
  - [ ] when you see a line that starts with:  ❌ - it can be gibberish 
  - [ ] Try to open the document 
  - [ ] example gibberish document https://www.morgenpost.de/sport/hertha/article235488157/Neustart-bei-Hertha-Auf-dieses-Trio-kommt-es-jetzt-an.html
 
![image](https://user-images.githubusercontent.com/180698/179708432-940c77cc-ac59-48e2-a03a-5b0707d8b3eb.png)
