### PR TITLE
TB-3978 Fix wrong timeAgo displayed in the card

### DIFF
--- a/application/lib/presentation/utils/time_ago.dart
+++ b/application/lib/presentation/utils/time_ago.dart
@@ -3,7 +3,9 @@ import 'package:xayn_discovery_app/presentation/constants/r.dart';
 
 String timeAgo(DateTime dateTime, DateFormat dateFormat) {
   final moment = DateTime.now();
-  final elapsed = moment.difference(dateTime);
+  final dateTimeWithOffset = dateTime.add(moment.timeZoneOffset);
+
+  final elapsed = moment.difference(dateTimeWithOffset);
   final minutesAgo = elapsed.inMinutes;
   final hoursAgo = elapsed.inHours;
   final daysAgo = elapsed.inDays;


### PR DESCRIPTION
### What 🕵️ 🔍

- What does the pull request solve?
Adds the local time zone offset to the date published before calculating the timesAgo

----------

### How to test (please adjust template) 🥼 🔬
- Feature flag enabled:
  Test main feature, and verify that all aspects of the story are working as described in the PR and the Jira story
  - [ ] Check that the `timesAgo` displayed is correct by checking the date of publication of an article. 
  
Please note: it might not be correct for all the news since sometimes it seems that the date we receive from the engine is the same of the date of publication

----------

### Screenshots 📸 📱

| Before | After  |
| ------ | ------ |
| <video width="280" src="https://user-images.githubusercontent.com/74236996/180179797-f7e98a68-a749-4d7e-bdf6-c71cf993e9f3.mov"> | <video width="280" src="https://user-images.githubusercontent.com/74236996/180179870-cc6e741f-0cec-404a-a9e3-51f3097c18b3.mov"> |







----------

### References 📝 🔗

- [JIRA](https://xainag.atlassian.net/browse/TB-3978)

----------