### PR TITLE
TY-3033 Remove visible subscription/trial info

### DIFF
--- a/application/lib/domain/model/feature.dart
+++ b/application/lib/domain/model/feature.dart
@@ -3,19 +3,17 @@ import 'package:xayn_discovery_app/presentation/utils/environment_helper.dart';
 enum Feature {
   featuresScreen(Owner.Michael,
       EnvironmentHelper.kIsDebug || EnvironmentHelper.kIsInternalFlavor),
-  payment(
-      Owner.Peter, EnvironmentHelper.kAppId == EnvironmentHelper.kReleaseAppId),
+  payment(Owner.Peter, false),
   discoveryEngineReportOverlay(Owner.Simon, false),
-  ratingDialog(Owner.Simon,
-      EnvironmentHelper.kIsDebug || EnvironmentHelper.kIsInternalFlavor),
+  ratingDialog(Owner.Simon, false),
   tts(Owner.Frank, false, 'Enables text-to-speech function for articles'),
 
   /// Keep flag for remote config
-  promptSurvey(Owner.Carmine, true,
+  promptSurvey(Owner.Carmine, false,
       'When enabled, collects the user interactions in order to prompt the survey card'),
 
   /// Keep flag for remote config
-  altPromoCode(Owner.Simon, true, 'PromoCodes are handled inApp'),
+  altPromoCode(Owner.Simon, false, 'PromoCodes are handled inApp'),
 
   pushNotificationDeepLinks(
     Owner.Peter,

--- a/application/lib/presentation/discovery_feed/manager/discovery_feed_manager.dart
+++ b/application/lib/presentation/discovery_feed/manager/discovery_feed_manager.dart
@@ -234,7 +234,8 @@ class DiscoveryFeedManager extends BaseDiscoveryManager
     final documentIds =
         state.cards.map((it) => it.document!.documentId).toSet();
     closeFeedDocuments(documentIds);
-    resetParameters();
+    resetCardIndex();
+    resetObservedDocument();
     requestNextFeedBatch();
   }
 

--- a/application/lib/presentation/personal_area/personal_area_screen.dart
+++ b/application/lib/presentation/personal_area/personal_area_screen.dart
@@ -13,7 +13,6 @@ import 'package:xayn_discovery_app/presentation/navigation/widget/nav_bar_items.
 import 'package:xayn_discovery_app/presentation/personal_area/manager/list_item_model.dart';
 import 'package:xayn_discovery_app/presentation/personal_area/manager/personal_area_manager.dart';
 import 'package:xayn_discovery_app/presentation/personal_area/manager/personal_area_state.dart';
-import 'package:xayn_discovery_app/presentation/premium/widgets/subscription_trial_banner.dart';
 import 'package:xayn_discovery_app/presentation/utils/overlay/overlay_manager.dart';
 import 'package:xayn_discovery_app/presentation/utils/overlay/overlay_mixin.dart';
 import 'package:xayn_discovery_app/presentation/utils/semantics_labels.dart';

--- a/application/lib/presentation/personal_area/personal_area_screen.dart
+++ b/application/lib/presentation/personal_area/personal_area_screen.dart
@@ -109,9 +109,7 @@ class PersonalAreaScreenState extends State<PersonalAreaScreen>
           collection: (itemModel) => _buildCard(
             itemModel.collection,
           ),
-          payment: (itemModel) => _buildTrialBanner(
-            itemModel.trialEndDate,
-          ),
+          payment: (itemModel) => Container(),
           contact: (_) => _buildContact(),
         );
         final isLastItem = index == screenState.items.length - 1;
@@ -181,14 +179,6 @@ class PersonalAreaScreenState extends State<PersonalAreaScreen>
         collectionCard: _buildBaseCard(collection),
         onSwipeOptionTap: _onSwipeOptionsTap(collection),
         onFling: _manager.triggerHapticFeedbackMedium,
-      );
-
-  Widget _buildTrialBanner(DateTime trialEndDate) => Padding(
-        padding: EdgeInsets.only(bottom: R.dimen.unit2),
-        child: SubscriptionTrialBanner(
-          trialEndDate: trialEndDate,
-          onPressed: _manager.onPaymentTrialBannerPressed,
-        ),
       );
 
   Map<SwipeOptionCollectionCard, VoidCallback> _onSwipeOptionsTap(


### PR DESCRIPTION
### What 🕵️ 🔍

- Removes the trial banner from personal area screen
- disables some features (like payment) not needed for the PoC
- fixes small bug with sending an event after closing a document

----------

### How to test (please adjust template) 🥼 🔬
- [ ] Verify that trial banner is removed from the personal area screen
- [ ] Verify that deep search works by pressing on the binocular
- [ ] Verify that if you go to settings and turn on "carousel" mode, then after reaching the end of the list in the feed, there will be a button to fetch more documents, instead of "infinite scroll", and new items will be fetched only after pressing that button. Fetching new items will "reset" the list, so the old documents won't be present anymore, only the newly fetched ones.


### Screen recording

[check it out here](https://slack-files.com/T69L64M6E-F03R5FFL5DL-07a3df32dc)

----------

### References 📝 🔗

- [JIRA](https://xainag.atlassian.net/browse/TY-3033)

----------