### PR TITLE
Changed free trial to 28 days in order to prevent users to leave the …

### DIFF
--- a/application/lib/domain/model/extensions/app_status_extension.dart
+++ b/application/lib/domain/model/extensions/app_status_extension.dart
@@ -1,6 +1,6 @@
 import 'package:xayn_discovery_app/domain/model/app_status.dart';
 
-const freeTrialDuration = Duration(days: 7);
+const freeTrialDuration = Duration(days: 28);
 
 extension AppStatusExtension on AppStatus {
   DateTime get trialEndDate {

--- a/application/lib/presentation/feature/manager/feature_manager.dart
+++ b/application/lib/presentation/feature/manager/feature_manager.dart
@@ -1,6 +1,7 @@
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:xayn_architecture/concepts/use_case/use_case_bloc_helper.dart';
+import 'package:xayn_discovery_app/domain/model/extensions/app_status_extension.dart';
 import 'package:xayn_discovery_app/domain/model/feature.dart';
 import 'package:xayn_discovery_app/domain/repository/app_status_repository.dart';
 import 'package:xayn_discovery_app/infrastructure/di/di_config.dart';
@@ -57,10 +58,8 @@ class FeatureManager extends Cubit<FeatureManagerState>
         _featureMap = modifiedFeatureMap;
       });
 
-  void flipFlopFeature(Feature feature) => overrideFeature(
-        feature,
-        isDisabled(feature),
-      );
+  void flipFlopFeature(Feature feature) =>
+      overrideFeature(feature, isDisabled(feature));
 
   void resetFirstAppStartupDate() {
     final appStatusRepo = di.get<AppStatusRepository>();
@@ -72,7 +71,7 @@ class FeatureManager extends Cubit<FeatureManagerState>
   void setTrialDurationToZero() {
     final appStatusRepo = di.get<AppStatusRepository>();
     final newStatus = appStatusRepo.appStatus.copyWith(
-      firstAppLaunchDate: DateTime.now().subtract(const Duration(days: 7)),
+      firstAppLaunchDate: DateTime.now().subtract(freeTrialDuration),
       extraTrialEndDate: null,
       usedPromoCodes: {},
     );


### PR DESCRIPTION
- affects:
  -  the trial period banner
  - old users should be able to just use the app longer because the check is done based on a comparison with the first startup date. 