### PR TITLE
Fix bugs in sources prompt

### DIFF
--- a/application/lib/infrastructure/use_case/inline_custom_card/inline_card_injection_use_case.dart
+++ b/application/lib/infrastructure/use_case/inline_custom_card/inline_card_injection_use_case.dart
@@ -34,10 +34,7 @@ class InLineCardInjectionUseCase
 
   @visibleForTesting
   bool shouldMarkInjectionPoint(InLineCardInjectionData data) =>
-      nextDocumentSibling == null &&
-      data.cardType != null &&
-      data.nextDocumentsCount > data.currentDocumentsCount &&
-      data.nextDocumentsCount > 2;
+      nextDocumentSibling == null && data.cardType != null;
 
   @visibleForTesting
   Iterable<Card> toCards(Set<Document> documents, CardType? cardType) sync* {

--- a/application/lib/presentation/feed_settings/page/source/manager/sources_manager.dart
+++ b/application/lib/presentation/feed_settings/page/source/manager/sources_manager.dart
@@ -6,9 +6,11 @@ import 'package:rxdart/rxdart.dart';
 import 'package:xayn_architecture/xayn_architecture.dart';
 import 'package:xayn_discovery_app/domain/model/sources_management/sources_management_operation.dart';
 import 'package:xayn_discovery_app/domain/model/sources_management/sources_management_task.dart';
+import 'package:xayn_discovery_app/domain/model/user_interactions/user_interactions_events.dart';
 import 'package:xayn_discovery_app/infrastructure/discovery_engine/use_case/engine_events_use_case.dart';
 import 'package:xayn_discovery_app/infrastructure/service/analytics/events/sources_management_single_changed_event.dart';
 import 'package:xayn_discovery_app/infrastructure/use_case/analytics/send_analytics_use_case.dart';
+import 'package:xayn_discovery_app/infrastructure/use_case/user_interactions/save_user_interaction_use_case.dart';
 import 'package:xayn_discovery_app/presentation/discovery_engine/mixin/sources_management_mixin.dart';
 import 'package:xayn_discovery_app/presentation/feed_settings/page/source/manager/sources_pending_operations.dart';
 import 'package:xayn_discovery_app/presentation/feed_settings/page/source/manager/sources_state.dart';
@@ -60,6 +62,7 @@ class SourcesManager extends Cubit<SourcesState>
   final SourcesPendingOperations sourcesPendingOperations;
   final SourcesScreenNavActions _sourcesScreenNavActions;
   final SendAnalyticsUseCase _sendAnalyticsUseCase;
+  final SaveUserInteractionUseCase _saveUserInteractionUseCase;
   late final FoldEngineEvent foldEngineEvent = _foldEngineEvent();
   late final UseCaseValueStream<SourcesState> nextStateValueStream = consume(
     engineEventsUseCase,
@@ -76,6 +79,7 @@ class SourcesManager extends Cubit<SourcesState>
     this._sendAnalyticsUseCase,
     this._sourcesScreenNavActions,
     this.engineEventsUseCase,
+    this._saveUserInteractionUseCase,
     this.sourcesPendingOperations,
   ) : super(const SourcesState());
 
@@ -230,6 +234,8 @@ class SourcesManager extends Cubit<SourcesState>
               isBatched: true,
             ),
           );
+          _saveUserInteractionUseCase(
+              UserInteractionsEvents.removeExcludedSource);
           break;
         case SourcesManagementTask.addToExcludedSources:
           excludedSources.add(operation.source);
@@ -240,6 +246,7 @@ class SourcesManager extends Cubit<SourcesState>
               isBatched: true,
             ),
           );
+          _saveUserInteractionUseCase(UserInteractionsEvents.excludedSource);
           break;
         case SourcesManagementTask.removeFromTrustedSources:
           trustedSources.remove(operation.source);
@@ -250,6 +257,8 @@ class SourcesManager extends Cubit<SourcesState>
               isBatched: true,
             ),
           );
+          _saveUserInteractionUseCase(
+              UserInteractionsEvents.removeTrustedSource);
           break;
         case SourcesManagementTask.addToTrustedSources:
           trustedSources.add(operation.source);
@@ -260,6 +269,7 @@ class SourcesManager extends Cubit<SourcesState>
               isBatched: true,
             ),
           );
+          _saveUserInteractionUseCase(UserInteractionsEvents.trustedSource);
           break;
       }
     }
@@ -282,7 +292,8 @@ class SourcesManager extends Cubit<SourcesState>
           sourceType = SourceType.excluded;
           sourceOperation =
               SourcesManagementSingleChangedEventOperation.removal;
-
+          _saveUserInteractionUseCase(
+              UserInteractionsEvents.removeExcludedSource);
           break;
         case SourcesManagementTask.addToExcludedSources:
           super.addSourceToExcludedList(operation.source);
@@ -290,7 +301,7 @@ class SourcesManager extends Cubit<SourcesState>
           sourceType = SourceType.excluded;
           sourceOperation =
               SourcesManagementSingleChangedEventOperation.addition;
-
+          _saveUserInteractionUseCase(UserInteractionsEvents.excludedSource);
           break;
         case SourcesManagementTask.removeFromTrustedSources:
           super.removeSourceFromTrustedList(operation.source);
@@ -298,7 +309,8 @@ class SourcesManager extends Cubit<SourcesState>
           sourceType = SourceType.trusted;
           sourceOperation =
               SourcesManagementSingleChangedEventOperation.removal;
-
+          _saveUserInteractionUseCase(
+              UserInteractionsEvents.removeTrustedSource);
           break;
         case SourcesManagementTask.addToTrustedSources:
           super.addSourceToTrustedList(operation.source);
@@ -306,7 +318,7 @@ class SourcesManager extends Cubit<SourcesState>
           sourceType = SourceType.trusted;
           sourceOperation =
               SourcesManagementSingleChangedEventOperation.addition;
-
+          _saveUserInteractionUseCase(UserInteractionsEvents.trustedSource);
           break;
       }
     }

--- a/application/test/presentation/feed_settings/page/source/manager/sources_manager_test.dart
+++ b/application/test/presentation/feed_settings/page/source/manager/sources_manager_test.dart
@@ -22,6 +22,7 @@ void main() {
   late MockAppDiscoveryEngine engine;
   late SourcesScreenNavActions navActions;
   late MockSendAnalyticsUseCase sendAnalyticsUseCase;
+  late MockSaveUserInteractionUseCase saveUserInteractionUseCase;
 
   final defaultExcludedSources = {
     Source('https://www.a.com'),
@@ -78,6 +79,7 @@ void main() {
     engine = MockAppDiscoveryEngine();
     navActions = MockSourcesScreenNavActions();
     sendAnalyticsUseCase = MockSendAnalyticsUseCase();
+    saveUserInteractionUseCase = MockSaveUserInteractionUseCase();
     eventsController = StreamController<EngineEvent>();
 
     when(engineEventsUseCase.transaction(any))
@@ -159,6 +161,7 @@ void main() {
       sendAnalyticsUseCase,
       navActions,
       engineEventsUseCase,
+      saveUserInteractionUseCase,
       sourcesPendingOperations,
     );
   });

--- a/application/test/test_utils/mocks.dart
+++ b/application/test/test_utils/mocks.dart
@@ -120,6 +120,7 @@ import 'package:xayn_discovery_app/infrastructure/use_case/reader_mode_settings/
 import 'package:xayn_discovery_app/infrastructure/use_case/reader_mode_settings/save_reader_mode_background_color_use_case.dart';
 import 'package:xayn_discovery_app/infrastructure/use_case/reader_mode_settings/save_reader_mode_font_size_use_case.dart';
 import 'package:xayn_discovery_app/infrastructure/use_case/reader_mode_settings/save_reader_mode_font_style_use_case.dart';
+import 'package:xayn_discovery_app/infrastructure/use_case/user_interactions/save_user_interaction_use_case.dart';
 import 'package:xayn_discovery_app/infrastructure/util/app_image_cache_manager.dart';
 import 'package:xayn_discovery_app/presentation/active_search/manager/active_search_manager.dart';
 import 'package:xayn_discovery_app/presentation/app/manager/app_manager.dart';
@@ -302,6 +303,7 @@ import 'package:xayn_discovery_engine/discovery_engine.dart';
   CanDisplayCountrySelectionUseCase,
   InLineCardManager,
   HandlePushNotificationsCardClickedUseCase,
+  SaveUserInteractionUseCase,
 ])
 class Mocks {
   Mocks._();


### PR DESCRIPTION
### What 🕵️ 🔍

- ensure the inline card shows after the exact number of scrolls
- update UserInteraction repository with trusted and excluded sources count.

----------

### How to test (please adjust template) 🥼 🔬
- enable sourcesPrompt feature
- scroll 5 times after a fresh install
- expect to see the inline card for source prompt
- delete the app and install again
- enable sourcesPrompt feature
- add a trusted/favourited source
- scroll 5 times
- expect not to see the inline card for source prompt

----------