### PR TITLE
ET-3459 Fix setting profile parameters in mixpanel for iOS

### DIFF
--- a/application/lib/infrastructure/service/analytics/analytics_service.dart
+++ b/application/lib/infrastructure/service/analytics/analytics_service.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:mixpanel_flutter/mixpanel_flutter.dart';
@@ -55,7 +57,7 @@ class MixpanelAnalyticsService with AsyncInitMixin implements AnalyticsService {
     _mixpanel.identify(_userId);
     _mixpanel.setUseIpAddressForGeolocation(false);
     _mixpanel.setLoggingEnabled(EnvironmentHelper.kIsInternalFlavor);
-    _preamble();
+    if (Platform.isAndroid) _preambleDeviceCores();
   }
 
   @factoryMethod
@@ -86,7 +88,7 @@ class MixpanelAnalyticsService with AsyncInitMixin implements AnalyticsService {
   }
 
   /// uses setOnce to log info on the device's cores
-  void _preamble() {
+  void _preambleDeviceCores() {
     final deviceCoresProperties = SysInfo.cores
         .map(
           (it) => {


### PR DESCRIPTION
### What 🕵️ 🔍

- `SysInfo.cores` crashes on iOS in `AnalyticsService` which causes Mixpanel service not to accept profile parameters consistently.
- The number of cores is only collected for Android.

----------

### How to test (please adjust template) 🥼 🔬
- Open the iOS
- Check Mixpanel for events
- Check the user profile (it should have experiments like this example: https://eu.mixpanel.com/project/2712349/view/3248657/app/profile#distinct_id=a07ff8d9-2ad1-460a-b5ec-106a4960b0be)

----------

### Screenshots 📸 📱

<img width="280" src="https://user-images.githubusercontent.com/12827629/196390964-bd863f30-582d-47ab-9916-1c0777282254.png"> 

----------

### References 📝 🔗

- [JIRA](https://xainag.atlassian.net/browse/ET-3459)

----------