### PR TITLE
change home indicator

### DIFF
--- a/application/pubspec.yaml
+++ b/application/pubspec.yaml
@@ -50,12 +50,7 @@ dependencies:
       ref: 0.1.0
   hive: 2.0.5
   hive_crdt: 2.0.2
-  # Pointing to a branch where the issue with "deprecated version of the Android embedding" is fixed.
-  # Should be updated the to next version when this PR is merged: https://github.com/RainwayApp/flutter_home_indicator/pull/10
-  home_indicator:
-    git:
-      url: https://github.com/nohli/flutter_home_indicator.git
-      ref: migrate-to-android-v2-embedding
+  home_indicator: 2.0.2
   http: 0.13.4
   html: 0.15.0
   html_unescape: 2.0.0


### PR DESCRIPTION
The HomeIndicator repo was deleted so that pub get would fail. Replace the hardcoded url with the official pub.dev package 